### PR TITLE
Fix & New Option for aapt2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,7 @@ Usage
          --arch TEXT       Support [arm, arm64, x86, x86_64]
          --skip-decompile
          --skip-recompile
+         --use-aapt2       Can be required for newer Android apps
          --help            Show this message and exit.
 
 Example

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -206,8 +206,9 @@ def inject_gadget_into_apk(apk_path:str, arch:str, decompiled_path:str):
 @click.option('--arch', default="arm64", help='Support [arm, arm64, x86, x86_64]')
 @click.option('--skip-decompile', is_flag=True)
 @click.option('--skip-recompile', is_flag=True)
+@click.option('--use-aapt2', is_flag=True, help="Can be required for newer Android apps")
 @click.argument('apk_path', type=click.Path(exists=True), required=True)
-def run(apk_path: str, skip_decompile:bool, skip_recompile:bool, arch: str):
+def run(apk_path: str, skip_decompile:bool, skip_recompile:bool, use_aapt2:bool, arch: str):
     """Patch an APK with the Frida gadget library
 
     Args:
@@ -248,7 +249,10 @@ def run(apk_path: str, skip_decompile:bool, skip_recompile:bool, arch: str):
 
     # Rebuild with apktool, print apk_path if process is success
     if not skip_recompile:
-        run_apktool('b', str(decompiled_path.resolve()))
+        if use_aapt2:
+            run_apktool('b --use-aapt2', str(decompiled_path.resolve()))
+        else:
+            run_apktool('b', str(decompiled_path.resolve()))
         apk_path = decompiled_path.joinpath('dist', apk_path.name)
         logger.info('Success: %s', str(apk_path.resolve()))
 

--- a/scripts/frida_github.py
+++ b/scripts/frida_github.py
@@ -105,6 +105,7 @@ class FridaGithub:
         if Path(gadget_fullpath).exists():
             return gadget_fullpath
 
+        Path(gadget_fullpath).parent.mkdir(parents=True, exist_ok=True)
         xz_gadget_fullpath = gadget_fullpath + ".xz"
         self.download_asset(url, xz_gadget_fullpath)
 


### PR DESCRIPTION
This is a PR to fix #9 and to add an option for apktool's `--use-aapt2` which is required if the app uses Gradle > 3.0.0. 

As a future option, if `invalid resource directory name` is inside the error from `apktool b`, the command could be ran again automatically with the `--use-aapt2` option.