### PR TITLE
Update cli.py

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -6,7 +6,7 @@ import subprocess
 from shutil import which
 from pathlib import Path
 import click
-from androguard.core.bytecodes.apk import APK
+from androguard.core.apk import APK 
 from .logger import logger
 from .__version__ import __version__
 from .frida_github import FridaGithub


### PR DESCRIPTION
androguard==4.0.0 doesn't has bytecodes, so to call APK you should use "from androguard.core.apk import APK" instead of "from androguard.core.bytecodes.apk import APK" otherwise you will get  an exception. or you need to set specific androguard version in requirements file