### PR TITLE
Fix signer prompt without a TTY and stop writing the js-delay wrapper next to the user's file

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -490,6 +490,18 @@ def inject_gadget_into_apk(
     return insert_loadlibary(decompiled_path, main_activity, load_library_name)
 
 
+def stdin_is_interactive():
+    """Check whether a child process could prompt on this stdin
+
+    Returns:
+        bool: True if stdin is attached to a terminal
+    """
+    try:
+        return sys.stdin is not None and sys.stdin.isatty()
+    except ValueError:  # stdin was already closed
+        return False
+
+
 def redact_passwords(cmd: list):
     """Hide keystore passwords in a command line before it is reported
 
@@ -544,7 +556,15 @@ def sign_apk(apk_path: str, ks: str = None, ks_alias: str = None, ks_key_pass: s
 
     # uber-apk-signer prompts for the passwords that were not provided,
     # which only works while it owns the terminal.
-    interactive = bool(ks) and not (ks_pass and ks_key_pass)
+    needs_prompt = bool(ks) and not (ks_pass and ks_key_pass)
+    interactive = needs_prompt and stdin_is_interactive()
+    if needs_prompt and not interactive:
+        logger.warning(
+            "There is no terminal attached, so uber-apk-signer cannot prompt for "
+            "the missing keystore password.\n"
+            "Run this from a terminal, or pass --ks-pass and --ks-key-pass."
+        )
+
     stdio = None if interactive else subprocess.PIPE
 
     with subprocess.Popen(

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -14,6 +14,7 @@ It provides various functionalities including:
 import os
 import re
 import sys
+import atexit
 import shutil
 import subprocess
 import json
@@ -795,8 +796,12 @@ def run(
             original_content = js_path.read_text()
             wrapped_content = wrap_js_with_timeout(original_content, js_delay)
 
-            # Create a temporary file with wrapped content
-            temp_js = js_path.parent / f"{js_path.stem}_wrapped{js_path.suffix}"
+            # Keep the wrapped copy in a private temporary directory. Writing it
+            # next to the original silently overwrote any existing file of that
+            # name and failed outright when the directory was read-only.
+            temp_dir = tempfile.mkdtemp(prefix="frida-gadget-")
+            atexit.register(shutil.rmtree, temp_dir, True)
+            temp_js = Path(temp_dir).joinpath("wrapped.js")
             temp_js.write_text(wrapped_content)
             js = str(temp_js)
             logger.debug("Created wrapped JavaScript file: %s", js)
@@ -936,17 +941,8 @@ def run(
         else:
             logger.info("Frida gadget injected into APK: %s", recompiled_apk_path)
 
-        # Clean up wrapped JavaScript file if it exists
-        if js and js_delay is not None:
-            temp_js = Path(js)
-            if temp_js.exists() and temp_js.name.endswith("_wrapped.js"):
-                try:
-                    temp_js.unlink()
-                    logger.debug("Cleaned up wrapped JavaScript file: %s", temp_js)
-                except Exception as e:
-                    logger.warning(
-                        "Failed to clean up wrapped JavaScript file: %s", str(e)
-                    )
+        # The wrapped JavaScript file is removed by the atexit hook that created it,
+        # so it no longer leaks when --skip-recompile is used or the run fails.
 
         # Copy original dex files except the modified one to the recompiled APK
         logger.debug(f"Copying original dex files (except modified one {modified_dex_number}) to the recompiled APK")


### PR DESCRIPTION
Two follow-ups from reviewing #38 / #39, plus the open SonarCloud alert.

### 1. Signing hangs when there is no terminal

#39 hands our stdin to uber-apk-signer so it can prompt for an omitted keystore password, but that only works with a real terminal. In CI or `docker run` without `-it`, `--ks` without `--ks-pass` would block forever waiting on a prompt nobody can answer.

Now the terminal is only handed over when stdin is a TTY; otherwise the previous piped behaviour is kept and a warning explains why no prompt appeared.

### 2. `--js-delay` wrapper written into the user's directory

`temp_js = js_path.parent / f"{js_path.stem}_wrapped{js_path.suffix}"` had three problems:

- it silently overwrote an existing `<name>_wrapped.js`
- it failed outright when the script sat in a read-only directory
- cleanup lived inside the `if not skip_recompile:` branch, so the file leaked with `--skip-recompile` or whenever the run raised

It now goes under `tempfile.mkdtemp()` and the directory is dropped by an `atexit` hook. Since the path no longer derives from `--js`, this also clears code scanning alert #3 (`pythonsecurity:S2083`, path injection) — which was a false positive as a vulnerability, the real bugs being the three above.

### Verified

- `stdin_is_interactive()` against tty / non-tty / closed / `None` stdin — no crash on any
- `sign_apk` with `--ks` and no passwords: piped + warning without a TTY, terminal handed over with one; default (no `--ks`) flow unchanged
- `--js-delay` run with a read-only script directory and a pre-existing `script_wrapped.js`: wrapper lands in the system temp dir, the existing file is untouched, no stray files appear next to the source, and the temp directory is gone after exit even with `--skip-recompile`
