### PR TITLE
Custom gadget file and custom GitHub repo support (rebase of #37 + fixes)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,9 +102,16 @@ Using Custom Frida Gadget File
 .. code:: sh
 
     $ frida-gadget target.apk --custom-gadget-path /path/to/your/frida-gadget.so --sign
-      [INFO] Using custom Frida gadget file: /path/to/your/frida-gadget.so
       [INFO] APK: '[REDACTED]/demo-apk/target.apk'
+      [INFO] Gadget Architecture(--arch): arm64(default)
+      [INFO] Using custom Frida gadget file: /path/to/your/frida-gadget.so
       ...
+
+| The file must be an uncompressed ``.so`` built for the architecture you pass to
+  ``--arch``. Frida publishes the gadget as ``.so.xz``, so decompress it first.
+| Because one library only matches one ABI, ``--custom-gadget-path`` cannot be
+  combined with ``--arch multi-arch``; run the command once per architecture.
+|
 
 Using Custom GitHub Repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -115,10 +122,11 @@ Using Custom GitHub Repository
 .. code:: sh
 
     $ frida-gadget target.apk --github-repo myuser/my-frida-fork --sign
-      [INFO] Using custom GitHub repository: myuser/my-frida-fork
-      [INFO] Auto-detected your frida version: 16.1.3
-      [DEBUG] Downloading the frida gadget library(16.1.3) for arm64 from custom repo
       [INFO] APK: '[REDACTED]/demo-apk/target.apk'
+      [INFO] Gadget Architecture(--arch): arm64(default)
+      [INFO] Auto-detected your frida version: 16.1.3
+      [INFO] Using custom GitHub repository: myuser/my-frida-fork
+      [DEBUG] Downloading the frida gadget library(16.1.3) for arm64
       ...
 
 | Or you can specify a full URL to the repository:
@@ -128,10 +136,14 @@ Using Custom GitHub Repository
 
     $ frida-gadget target.apk --github-repo https://github.com/myuser/my-frida-fork --sign
       [INFO] Using custom GitHub repository: https://github.com/myuser/my-frida-fork
-      [INFO] Auto-detected your frida version: 16.1.3
-      [DEBUG] Downloading the frida gadget library(16.1.3) for arm64 from custom repo
-      [INFO] APK: '[REDACTED]/demo-apk/target.apk'
       ...
+
+| The repository must publish its releases the same way frida does: a release
+  tagged with the version being used, holding an asset named
+  ``frida-gadget-<version>-android-<arch>.so.xz``. Otherwise the download fails
+  with ``not found in the github releases``.
+| Only ``github.com`` repositories are accepted, given either as ``owner/repo``
+  or as a github.com URL.
 
 With Docker
 ~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,8 @@ Usage
          --js-delay INTEGER         Specify seconds to wait before executing the JavaScript file.
          --force-manifest           Force modify AndroidManifest.xml even if it already has required permissions.
          --custom-gadget-name TEXT  Specify a custom name for the Frida gadget.
+         --custom-gadget-path TEXT  Use a custom Frida gadget library file instead of downloading from GitHub.
+         --github-repo TEXT         Specify a custom GitHub repository for downloading Frida gadget (e.g., username/repo-name or full URL).
          --no-res                   Skip decoding resources.
          --main-activity TEXT       Specify the main activity if known.
          --sign                     Automatically sign the APK using uber-apk-signer.
@@ -90,6 +92,46 @@ How do I begin?
       [DEBUG] Recompiling the new APK using apktool
       ...
       [INFO] APK signing finished: ./target/dist/target-aligned-debugSigned.apk (72.78 MiB)
+
+Using Custom Frida Gadget File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+| You can also provide your own custom Frida gadget file instead of downloading from GitHub.
+| This is useful when you need to use a custom compiled gadget or when you want to work offline.
+|
+
+.. code:: sh
+
+    $ frida-gadget target.apk --custom-gadget-path /path/to/your/frida-gadget.so --sign
+      [INFO] Using custom Frida gadget file: /path/to/your/frida-gadget.so
+      [INFO] APK: '[REDACTED]/demo-apk/target.apk'
+      ...
+
+Using Custom GitHub Repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+| You can also specify a custom GitHub repository to download the Frida gadget from.
+| This is useful when you need to use a custom or forked version of Frida.
+|
+
+.. code:: sh
+
+    $ frida-gadget target.apk --github-repo myuser/my-frida-fork --sign
+      [INFO] Using custom GitHub repository: myuser/my-frida-fork
+      [INFO] Auto-detected your frida version: 16.1.3
+      [DEBUG] Downloading the frida gadget library(16.1.3) for arm64 from custom repo
+      [INFO] APK: '[REDACTED]/demo-apk/target.apk'
+      ...
+
+| Or you can specify a full URL to the repository:
+|
+
+.. code:: sh
+
+    $ frida-gadget target.apk --github-repo https://github.com/myuser/my-frida-fork --sign
+      [INFO] Using custom GitHub repository: https://github.com/myuser/my-frida-fork
+      [INFO] Auto-detected your frida version: 16.1.3
+      [DEBUG] Downloading the frida gadget library(16.1.3) for arm64 from custom repo
+      [INFO] APK: '[REDACTED]/demo-apk/target.apk'
+      ...
 
 With Docker
 ~~~~~~~~~~~~~~~~~~

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -96,8 +96,6 @@ def download_gadget(
 
     if custom_gadget_path:
         logger.info("Using custom Frida gadget file: %s", custom_gadget_path)
-        import shutil
-        from pathlib import Path
 
         file_ext = Path(custom_gadget_path).suffix
         dest_filename = (

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -451,8 +451,8 @@ def inject_gadget_into_apk(
                         "The config file must contain an 'interaction.type' key."
                     )
                     sys.exit(-1)
-                if config_data["interaction"]["type"] == (
-                    "script-directory" or "script"
+                if config_data["interaction"]["type"] in (
+                    "script-directory", "script"
                 ):
                     if "path" not in config_data["interaction"]:
                         logger.error(

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -73,12 +73,19 @@ def run_apktool(option: list, apk_path: str):
         return True
 
 
-def download_gadget(arch: str, frida_version: str = None):
-    """Download the frida gadget library
+def download_gadget(
+    arch: str,
+    frida_version: str = None,
+    custom_gadget_path: str = None,
+    github_repo: str = None,
+):
+    """Download the frida gadget library or use a custom file
 
     Args:
         arch (str): architecture of the device
         frida_version (str): specific frida version to use
+        custom_gadget_path (str): path to custom frida gadget file
+        github_repo (str): custom GitHub repository for the frida gadget
     """
     if frida_version:
         logger.info("Using specified frida version: %s", frida_version)
@@ -87,7 +94,23 @@ def download_gadget(arch: str, frida_version: str = None):
         logger.info("Auto-detected your frida version: %s", INSTALLED_FRIDA_VERSION)
         version = INSTALLED_FRIDA_VERSION
 
-    frida_github = FridaGithub(version)
+    if custom_gadget_path:
+        logger.info("Using custom Frida gadget file: %s", custom_gadget_path)
+        import shutil
+        from pathlib import Path
+
+        file_ext = Path(custom_gadget_path).suffix
+        dest_filename = (
+            f"frida-gadget-custom-{arch}{file_ext}"
+            if file_ext
+            else f"frida-gadget-custom-{arch}.so"
+        )
+        so_gadget_path = str(FILE_DIR.joinpath(dest_filename))
+
+        shutil.copy2(custom_gadget_path, so_gadget_path)
+        return so_gadget_path
+
+    frida_github = FridaGithub(version, github_repo)
     assets = frida_github.get_assets()
     file = f"frida-gadget-{version}-android-{arch}.so.xz"
     for asset in assets:
@@ -260,15 +283,17 @@ def detect_apk_architectures(decompiled_path):
 def inject_gadget_into_apk(
     apk_path: str,
     arch: str,
-    decompiled_path: str,
-    no_res,
-    force_manifest,
+    decompiled_path: Path,
+    no_res: bool,
+    force_manifest: bool,
     main_activity: str = None,
     config: str = None,
     js: str = None,
     custom_gadget_name: str = None,
+    custom_gadget_path: str = None,
     frida_version: str = None,
-):
+    github_repo: str = None,
+) -> int:
     """Inject frida gadget into an APK
 
     Args:
@@ -318,7 +343,9 @@ def inject_gadget_into_apk(
         modify_manifest(decompiled_path)
 
     for current_arch in archs:
-        gadget_path = download_gadget(current_arch, frida_version)
+        gadget_path = download_gadget(
+            current_arch, frida_version, custom_gadget_path, github_repo
+        )
         gadget_name = Path(gadget_path).name
 
         # Apply custom gadget name if provided
@@ -369,6 +396,11 @@ def inject_gadget_into_apk(
                 if "interaction" not in config_data:
                     logger.error("The config file must contain an 'interaction' key.")
                     sys.exit(-1)
+                if "type" not in config_data["interaction"]:
+                    logger.error(
+                        "The config file must contain an 'interaction.type' key."
+                    )
+                    sys.exit(-1)
                 if "path" in config_data["interaction"]:
                     logger.debug(
                         "Updating the script path in '%s' from '%s' to 'lib%s.script.so'",
@@ -414,13 +446,23 @@ def inject_gadget_into_apk(
                 if "interaction" not in config_data:
                     logger.error("The config file must contain an 'interaction' key.")
                     sys.exit(-1)
-                if "path" not in config_data["interaction"]:
-                    logger.error("The config file must contain a 'path' key.")
+                if "type" not in config_data["interaction"]:
+                    logger.error(
+                        "The config file must contain an 'interaction.type' key."
+                    )
                     sys.exit(-1)
-                logger.warning(
-                    "The script file must be located at '%s' on your device",
-                    config_data["interaction"]["path"],
-                )
+                if config_data["interaction"]["type"] == (
+                    "script-directory" or "script"
+                ):
+                    if "path" not in config_data["interaction"]:
+                        logger.error(
+                            "The config file must contain a 'interaction.path' key with 'type: script' or 'type: script-directory'"
+                        )
+                        sys.exit(-1)
+                    logger.warning(
+                        "The script file must be located at '%s' on your Android device",
+                        config_data["interaction"]["path"],
+                    )
 
         for file_type, file_path in upload_files.items():
             if file_path:
@@ -446,7 +488,13 @@ def inject_gadget_into_apk(
     return insert_loadlibary(decompiled_path, main_activity, load_library_name)
 
 
-def sign_apk(apk_path: str, ks: str = None, ks_alias: str = None, ks_key_pass: str = None, ks_pass: str = None):
+def sign_apk(
+    apk_path: str,
+    ks: str = None,
+    ks_alias: str = None,
+    ks_key_pass: str = None,
+    ks_pass: str = None,
+):
     """Run uber apk signer with option
 
     Args:
@@ -597,6 +645,17 @@ def wrap_js_with_timeout(js_content: str, delay: int) -> str:
     default=None,
     help="Specify a custom name for the Frida gadget.",
 )
+@click.option(
+    "--custom-gadget-path",
+    default=None,
+    type=click.Path(exists=True),
+    help="Use a custom Frida gadget library file instead of downloading from GitHub.",
+)
+@click.option(
+    "--github-repo",
+    default=None,
+    help="Specify a custom GitHub repository for downloading Frida gadget (e.g., username/repo-name or full URL).",
+)
 @click.option("--no-res", is_flag=True, help="Skip decoding resources.")
 @click.option(
     "--main-activity", default=None, help="Specify the main activity if known."
@@ -646,6 +705,7 @@ def run(
     main_activity: str,
     sign: bool,
     custom_gadget_name: str,
+    custom_gadget_path: str,
     js: str,
     js_delay: int,
     force_manifest: bool,
@@ -660,6 +720,7 @@ def run(
     ks_alias: str,
     ks_key_pass: str,
     ks_pass: str,
+    github_repo: str,
 ):
     """Patch an APK with the Frida gadget library"""
     apk_path = Path(apk_path)
@@ -811,7 +872,9 @@ def run(
         config,
         js,
         custom_gadget_name,
+        custom_gadget_path,
         frida_version,
+        github_repo,
     )
 
     # Rebuild with apktool, print apk_path if process is success
@@ -844,7 +907,9 @@ def run(
                     )
 
         # Copy original dex files except the modified one to the recompiled APK
-        logger.debug(f"Copying original dex files (except modified one {modified_dex_number}) to the recompiled APK")
+        logger.debug(
+            f"Copying original dex files (except modified one {modified_dex_number}) to the recompiled APK"
+        )
         try:
             # Create a temporary directory for extraction
             with tempfile.TemporaryDirectory() as temp_dir:
@@ -866,8 +931,11 @@ def run(
                 new_apk = zipfile.ZipFile(temp_file_path, 'w')
 
                 # Copy all files from recompiled APK except dex files
-                modified_dex_filename = f"classes{modified_dex_number}.dex" \
-                    if modified_dex_number and modified_dex_number > 1 else "classes.dex"
+                modified_dex_filename = (
+                    f"classes{modified_dex_number}.dex"
+                    if modified_dex_number and modified_dex_number > 1
+                    else "classes.dex"
+                )
 
                 for item in recompiled_apk.infolist():
                     if item.filename == modified_dex_filename:

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -131,6 +131,23 @@ def download_gadget(
         custom_gadget_path (str): path to custom frida gadget file
         github_repo (str): custom GitHub repository for the frida gadget
     """
+    # A custom gadget is used as-is, so the frida version is irrelevant here
+    if custom_gadget_path:
+        logger.info("Using custom Frida gadget file: %s", custom_gadget_path)
+
+        source = Path(custom_gadget_path)
+        if source.suffix != ".so":
+            raise ValueError(
+                f"The custom gadget must be an uncompressed '.so' file, got '{source.name}'.\n"
+                "Frida publishes the gadget as '.so.xz', so decompress it first."
+            )
+
+        # FILE_DIR is normally created while downloading, which we skip here
+        FILE_DIR.mkdir(parents=True, exist_ok=True)
+        so_gadget_path = str(FILE_DIR.joinpath(f"frida-gadget-custom-{arch}.so"))
+        shutil.copy2(source, so_gadget_path)
+        return so_gadget_path
+
     if frida_version:
         logger.info("Using specified frida version: %s", frida_version)
         version = frida_version
@@ -138,19 +155,8 @@ def download_gadget(
         logger.info("Auto-detected your frida version: %s", INSTALLED_FRIDA_VERSION)
         version = INSTALLED_FRIDA_VERSION
 
-    if custom_gadget_path:
-        logger.info("Using custom Frida gadget file: %s", custom_gadget_path)
-
-        file_ext = Path(custom_gadget_path).suffix
-        dest_filename = (
-            f"frida-gadget-custom-{arch}{file_ext}"
-            if file_ext
-            else f"frida-gadget-custom-{arch}.so"
-        )
-        so_gadget_path = str(FILE_DIR.joinpath(dest_filename))
-
-        shutil.copy2(custom_gadget_path, so_gadget_path)
-        return so_gadget_path
+    if github_repo:
+        logger.info("Using custom GitHub repository: %s", github_repo)
 
     frida_github = FridaGithub(version, github_repo)
     assets = frida_github.get_assets()
@@ -812,6 +818,15 @@ def run(
         arch = "arm64"
     elif arch == "armeabi-v7a":
         arch = "arm"
+
+    # A single library file only matches one ABI, so it cannot serve every
+    # architecture found in the APK
+    if custom_gadget_path and arch == "multi-arch":
+        logger.error(
+            "The --custom-gadget-path option cannot be combined with '--arch multi-arch'.\n"
+            "Run the command once per architecture instead."
+        )
+        sys.exit(-1)
 
     # Validate js-delay option
     if js_delay is not None:

--- a/scripts/frida_github.py
+++ b/scripts/frida_github.py
@@ -2,15 +2,23 @@
 # Base code is sourced from the GitHub repository of Objection.
 # Source: https://github.com/sensepost/objection/blob/master/objection/utils/patchers/github.py
 import lzma
+import re
 from pathlib import Path
 import requests
-import re
 
 class FridaGithub:
     """ Interact with Github """
 
-    DEFAULT_GITHUB_LATEST_RELEASE = 'https://api.github.com/repos/frida/frida/releases/latest'
-    DEFAULT_GITHUB_TAGGED_RELEASE = 'https://api.github.com/repos/frida/frida/releases/tags/{tag}'
+    DEFAULT_GITHUB_API_BASE = 'https://api.github.com/repos/frida/frida'
+
+    # 'owner/repo', or a github.com URL with an optional scheme, 'www.',
+    # '.git' suffix and trailing slash. Any other host is rejected so a
+    # typo cannot send the request somewhere unexpected.
+    GITHUB_REPO_PATTERN = re.compile(
+        r'^(?:(?:https?://)?(?:www\.)?github\.com/)?'
+        r'(?P<owner>[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)/'
+        r'(?P<repo>[A-Za-z0-9._-]+?)(?:\.git)?/?$'
+    )
 
     # the 'context' of this Github instance
     gadget_version = None
@@ -23,26 +31,29 @@ class FridaGithub:
 
         if gadget_version:
             self.gadget_version = gadget_version
-            
-        # Set GitHub API base URL based on custom repo or default
-        if github_repo:
-            if github_repo.startswith(('https://', 'github.com')):
-                match = re.search(r'\.com/([^/]+)/([^/]+)', github_repo)
-                if match:
-                    owner, repo = match.groups()
-                    self.github_api_base = f'https://api.github.com/repos/{owner}/{repo}'
-                else:
-                    raise ValueError(f"Invalid GitHub repository URL: {github_repo}")
-            else:
-                # Just owner/repo provided
-                if '/' in github_repo:
-                    self.github_api_base = f'https://api.github.com/repos/{github_repo}'
-                else:
-                    raise ValueError(f"Invalid GitHub repository format (expected 'owner/repo'): {github_repo}")
-        else:
-            self.github_api_base = 'https://api.github.com/repos/frida/frida'
-            
+
+        self.github_api_base = self.parse_repo(github_repo)
         self.request_cache = {}
+
+    @classmethod
+    def parse_repo(cls, github_repo: str) -> str:
+        """
+            Turn a repository reference into a Github API base URL.
+
+            :param github_repo: 'owner/repo' or a github.com URL, empty for frida/frida
+            :return:
+        """
+
+        if not github_repo:
+            return cls.DEFAULT_GITHUB_API_BASE
+
+        match = cls.GITHUB_REPO_PATTERN.match(github_repo.strip())
+        if not match:
+            raise ValueError(
+                'Invalid GitHub repository '
+                f'(expected \'owner/repo\' or a github.com URL): {github_repo}')
+
+        return f'https://api.github.com/repos/{match.group("owner")}/{match.group("repo")}'
 
     @property
     def GITHUB_LATEST_RELEASE(self):

--- a/scripts/frida_github.py
+++ b/scripts/frida_github.py
@@ -4,25 +4,53 @@
 import lzma
 from pathlib import Path
 import requests
+import re
 
 class FridaGithub:
     """ Interact with Github """
 
-    GITHUB_LATEST_RELEASE = 'https://api.github.com/repos/frida/frida/releases/latest'
-    GITHUB_TAGGED_RELEASE = 'https://api.github.com/repos/frida/frida/releases/tags/{tag}'
+    DEFAULT_GITHUB_LATEST_RELEASE = 'https://api.github.com/repos/frida/frida/releases/latest'
+    DEFAULT_GITHUB_TAGGED_RELEASE = 'https://api.github.com/repos/frida/frida/releases/tags/{tag}'
 
     # the 'context' of this Github instance
     gadget_version = None
+    github_api_base = None
 
-    def __init__(self, gadget_version: str = None):
+    def __init__(self, gadget_version: str = "", github_repo: str = ""):
         """
             Init a new instance of Github
         """
 
         if gadget_version:
             self.gadget_version = gadget_version
-
+            
+        # Set GitHub API base URL based on custom repo or default
+        if github_repo:
+            if github_repo.startswith(('http://', 'https://', 'github.com')):
+                match = re.search(r'\.com/([^/]+)/([^/]+)', github_repo)
+                if match:
+                    owner, repo = match.groups()
+                    self.github_api_base = f'https://api.github.com/repos/{owner}/{repo}'
+                else:
+                    raise ValueError(f"Invalid GitHub repository URL: {github_repo}")
+            else:
+                # Just owner/repo provided
+                if '/' in github_repo:
+                    self.github_api_base = f'https://api.github.com/repos/{github_repo}'
+                else:
+                    raise ValueError(f"Invalid GitHub repository format (expected 'owner/repo'): {github_repo}")
+        else:
+            self.github_api_base = 'https://api.github.com/repos/frida/frida'
+            
         self.request_cache = {}
+
+    @property
+    def GITHUB_LATEST_RELEASE(self):
+        return f'{self.github_api_base}/releases/latest'
+
+    @property
+    def GITHUB_TAGGED_RELEASE(self):
+        return f'{self.github_api_base}/releases/tags/{{tag}}'
 
     def _call(self, endpoint: str) -> dict:
         """

--- a/scripts/frida_github.py
+++ b/scripts/frida_github.py
@@ -26,7 +26,7 @@ class FridaGithub:
             
         # Set GitHub API base URL based on custom repo or default
         if github_repo:
-            if github_repo.startswith(('http://', 'https://', 'github.com')):
+            if github_repo.startswith(('https://', 'github.com')):
                 match = re.search(r'\.com/([^/]+)/([^/]+)', github_repo)
                 if match:
                     owner, repo = match.groups()


### PR DESCRIPTION
Picks up @ObjShadow's work in #37, brings it onto current `trunk`, and fixes what came up in review. Their original commits are kept, so credit stays with them.

Supersedes #37 — the branch there is 6 months old and conflicts with #38/#39.

### Rebase

One conflict: #37 reformatted the `sign_apk` signature while #39 added `redact_passwords` right above it. Both kept.

### Fixes on top

| | |
|---|---|
| `--custom-gadget-path` crashed on any fresh install | `FILE_DIR` is only created on the download path, which this branch skips, so `shutil.copy2` raised `FileNotFoundError`. Reproduced before fixing. |
| `--custom-gadget-path` accepted `.so.xz` | Frida ships the gadget compressed. The archive was copied straight into `lib/<abi>/`, so the build succeeded and only failed on the device at `loadLibrary`. Now rejected up front. |
| `--custom-gadget-path` + `--arch multi-arch` | One library matches one ABI, but it was copied into every `lib/<abi>` directory. Now rejected with a message pointing at the per-architecture workaround. |
| `http://github.com/owner/repo` | Fell through to the `owner/repo` branch and built `https://api.github.com/repos/http://github.com/owner/repo`. |
| `https://evil.com/a/b` | The `\.com/([^/]+)/([^/]+)` search matched any `.com` host. Parsing is now anchored and github.com-only. |
| `owner/repo.git` | The `.git` suffix was kept and sent to the API. |
| Misleading frida version log | `Auto-detected your frida version` printed even with a custom gadget, where the version is irrelevant. Version detection now happens only on the download path. |

Also logs the repository in use (the README example in #37 showed that line, but nothing emitted it), and documents the `.so` requirement, the multi-arch restriction, and the release asset naming a fork has to follow — `frida-gadget-<version>-android-<arch>.so.xz`, otherwise the download fails with `not found in the github releases`.

The unrelated `interaction.type` fix from #37 — configs using `listen` or `connect` no longer require a `path` key — is carried over unchanged.

### Verified

- Repo parsing accepts `owner/repo`, bare `github.com/...`, `http://`, `https://`, `www.`, trailing `/`, `.git`; rejects `evil.com/a/b`, `https://evil.com/frida/frida`, `gitlab.com`, bare `justrepo`, `owner/repo/extra`, owner-only URLs; empty input still resolves to `frida/frida`
- `--custom-gadget-path` with `scripts/files/` absent copies the gadget successfully; a `.so.xz` is rejected
- `--arch multi-arch` with `--custom-gadget-path` exits non-zero; `--arch arm64` with it still succeeds
