### PR TITLE
Clear the SonarCloud and Codacy findings, and cover the code with tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,44 @@
 FROM eclipse-temurin:17-jdk-jammy
-LABEL MAINTAINER ksg97031 (ksg97031@gmail.com)
+LABEL maintainer="ksg97031 <ksg97031@gmail.com>"
+
+ARG APKTOOL_VERSION=2.11.1
+ENV APKTOOL_VERSION=${APKTOOL_VERSION}
 
 # Install dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        ca-certificates \
         curl \
+        python-is-python3 \
         python3 \
         python3-pip \
-        python-is-python3 \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Frida
-RUN pip3 install --no-cache-dir --upgrade pip && \
-    pip3 install --no-cache-dir frida
-
-# Install apktool
-ENV APKTOOL_VERSION=2.11.1 
+# Install apktool. The launcher script and the jar are fetched over HTTPS with
+# --proto '=https' so a redirect cannot downgrade the transfer to plain HTTP.
 WORKDIR /usr/local/bin
-RUN curl -sLO https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/linux/apktool && \
-    chmod +x apktool
-RUN curl -sL -o apktool.jar https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_${APKTOOL_VERSION}.jar && \
-    chmod +x apktool.jar
+RUN curl -fsSL --proto '=https' --tlsv1.2 \
+        -o apktool \
+        https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/linux/apktool && \
+    curl -fsSL --proto '=https' --tlsv1.2 \
+        -o apktool.jar \
+        "https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_${APKTOOL_VERSION}.jar" && \
+    chmod +x apktool apktool.jar
 
 # Create a non-root user
 RUN useradd -m -s /bin/bash frida-user
 
-# Install dependencies
+# Install python dependencies. '--only-binary :all:' installs wheels only, so no
+# package can run setup code while the image is being built. frida is imported
+# by scripts/__init__.py to read the version the gadget is matched against.
 WORKDIR /workspace
-COPY scripts /workspace/scripts
 COPY requirements.txt /workspace/requirements.txt
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN pip3 install --no-cache-dir --only-binary :all: --upgrade pip && \
+    pip3 install --no-cache-dir --only-binary :all: frida && \
+    pip3 install --no-cache-dir --only-binary :all: -r requirements.txt
+
+COPY scripts /workspace/scripts
 
 # Set ownership of workspace directory
 RUN chown -R frida-user:frida-user /workspace

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -5,7 +5,7 @@ from .logger import logger
 
 
 def import_or_install(package):
-    """Function to install missing packages.
+    """Install a package, or exit asking the user to try again.
 
     Args:
         package (string): Name of the package to install.

--- a/scripts/__version__.py
+++ b/scripts/__version__.py
@@ -1,5 +1,4 @@
 """frida-gadget version information."""
-
 __title__ = "frida-gadget"
 __version__ = "1.6.2"
 __description__ = "Automated Frida Gadget injection tool"

--- a/scripts/apk_utils.py
+++ b/scripts/apk_utils.py
@@ -1,56 +1,127 @@
+"""Helpers for reading activity information out of an APK manifest"""
 from androguard.core.apk import APK
 
 from .logger import logger
 
-def get_main_activity(apk:APK):
-    x = set()
-    y = set()
+# Fixed by the Android manifest format, so reading attributes does not depend
+# on androguard internals. tests/test_apk_utils.py checks it still agrees with
+# androguard's own constant.
+ANDROID_NS = "{http://schemas.android.com/apk/res/android}"
 
-    for i in apk.xml:
-        if apk.xml[i] is None:
+MAIN_ACTION = "android.intent.action.MAIN"
+LAUNCHER_CATEGORY = "android.intent.category.LAUNCHER"
+
+
+def android_attr(element, name: str):
+    """Read an 'android:' namespaced attribute off a manifest element
+
+    Args:
+        element: manifest element
+        name (str): attribute name without the namespace
+
+    Returns:
+        str: the attribute value, or None when it is absent
+    """
+    return element.get(ANDROID_NS + name)
+
+
+def iter_activities(apk: APK):
+    """Yield every activity and activity-alias declared in the manifest
+
+    Args:
+        apk (APK): parsed apk file
+
+    Yields:
+        the manifest elements, skipping the ones that are explicitly disabled
+    """
+    for manifest in apk.xml.values():
+        if manifest is None:
             continue
-        activities_and_aliases = apk.xml[i].findall(".//activity") + \
-                                    apk.xml[i].findall(".//activity-alias")
 
-        for item in activities_and_aliases:
-            # Some applications have more than one MAIN activity.
-            # For example: paid and free content
-            activityEnabled = item.get(apk._ns("enabled"))
-            if activityEnabled == "false":
+        elements = manifest.findall(".//activity") + manifest.findall(".//activity-alias")
+        for element in elements:
+            # Some applications have more than one MAIN activity,
+            # for example a paid and a free variant
+            if android_attr(element, "enabled") == "false":
                 continue
 
-            for sitem in item.findall(".//action"):
-                val = sitem.get(apk._ns("name"))
-                if val == "android.intent.action.MAIN":
-                    activity = item.get(apk._ns("name"))
-                    target_activity = item.get(apk._ns("targetActivity"))
-                    if target_activity is not None:
-                        logger.debug('Target activity found: %s -> %s', activity, target_activity)
-                        activity = target_activity
-                    if activity is not None:
-                        x.add(activity)
-                    else:
-                        logger.warning('Main activity without name')
+            yield element
 
-            for sitem in item.findall(".//category"):
-                val = sitem.get(apk._ns("name"))
-                if val == "android.intent.category.LAUNCHER":
-                    activity = item.get(apk._ns("name"))
-                    target_activity = item.get(apk._ns("targetActivity"))
-                    if target_activity is not None:
-                        activity = target_activity
-                    if activity is not None:
-                        y.add(activity)
-                    else:
-                        logger.warning('Launcher activity without name')
 
-    activities = x.intersection(y)
-    if len(activities) == 0:
+def resolve_activity_name(element):
+    """Resolve the class an activity entry points at
+
+    An activity-alias points at another activity through 'targetActivity',
+    which is the class that actually has to be patched.
+
+    Args:
+        element: manifest element of an activity or activity-alias
+
+    Returns:
+        str: the class name, or None when the entry has neither attribute
+    """
+    activity = android_attr(element, "name")
+    target_activity = android_attr(element, "targetActivity")
+    if target_activity is not None:
+        logger.debug("Target activity found: %s -> %s", activity, target_activity)
+        return target_activity
+
+    return activity
+
+
+def declares(element, tag: str, value: str) -> bool:
+    """Check whether an activity declares an intent filter entry
+
+    Args:
+        element: manifest element of an activity or activity-alias
+        tag (str): child tag to look at, 'action' or 'category'
+        value (str): the android:name the child has to carry
+
+    Returns:
+        bool: True when at least one child matches
+    """
+    return any(
+        android_attr(child, "name") == value for child in element.findall(f".//{tag}")
+    )
+
+
+def get_main_activity(apk: APK):
+    """Find the activity the launcher starts
+
+    Args:
+        apk (APK): parsed apk file
+
+    Returns:
+        str: the main activity class name,
+             None when the manifest declares none,
+             -1 when it declares more than one
+    """
+    mains = set()
+    launchers = set()
+
+    for element in iter_activities(apk):
+        is_main = declares(element, "action", MAIN_ACTION)
+        is_launcher = declares(element, "category", LAUNCHER_CATEGORY)
+        if not is_main and not is_launcher:
+            continue
+
+        name = resolve_activity_name(element)
+        if name is None:
+            logger.warning("Activity without name in the manifest")
+            continue
+
+        if is_main:
+            mains.add(name)
+        if is_launcher:
+            launchers.add(name)
+
+    activities = mains & launchers
+    if not activities:
         return None
-    elif len(activities) > 1:
+
+    if len(activities) > 1:
         logger.error("Multiple main activities found: %s", activities)
-        logger.error('Please specify one using the --main-activity option.')
+        logger.error("Please specify one using the --main-activity option.")
         return -1
 
-    main_activity = activities.pop()
-    return main_activity
+    return activities.pop()

--- a/scripts/apk_utils.py
+++ b/scripts/apk_utils.py
@@ -1,4 +1,4 @@
-"""Helpers for reading activity information out of an APK manifest"""
+"""Helpers for reading activity information out of an APK manifest."""
 from androguard.core.apk import APK
 
 from .logger import logger
@@ -13,7 +13,7 @@ LAUNCHER_CATEGORY = "android.intent.category.LAUNCHER"
 
 
 def android_attr(element, name: str):
-    """Read an 'android:' namespaced attribute off a manifest element
+    """Read an 'android:' namespaced attribute off a manifest element.
 
     Args:
         element: manifest element
@@ -26,7 +26,7 @@ def android_attr(element, name: str):
 
 
 def iter_activities(apk: APK):
-    """Yield every activity and activity-alias declared in the manifest
+    """Yield every activity and activity-alias declared in the manifest.
 
     Args:
         apk (APK): parsed apk file
@@ -49,7 +49,7 @@ def iter_activities(apk: APK):
 
 
 def resolve_activity_name(element):
-    """Resolve the class an activity entry points at
+    """Resolve the class an activity entry points at.
 
     An activity-alias points at another activity through 'targetActivity',
     which is the class that actually has to be patched.
@@ -70,7 +70,7 @@ def resolve_activity_name(element):
 
 
 def declares(element, tag: str, value: str) -> bool:
-    """Check whether an activity declares an intent filter entry
+    """Check whether an activity declares an intent filter entry.
 
     Args:
         element: manifest element of an activity or activity-alias
@@ -86,7 +86,7 @@ def declares(element, tag: str, value: str) -> bool:
 
 
 def get_main_activity(apk: APK):
-    """Find the activity the launcher starts
+    """Find the activity the launcher starts.
 
     Args:
         apk (APK): parsed apk file

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -839,7 +839,7 @@ def restore_original_dex(apk_path, recompiled_apk_path, modified_dex_number):
                 original_apk.extractall(temp_dir_path)
 
             # Built inside the temporary directory so a failure cannot leave a
-            # stray file behind, and the move below stays on one filesystem
+            # stray file behind the way the old NamedTemporaryFile did
             staged_apk_path = temp_dir_path.joinpath("repacked.apk")
             with zipfile.ZipFile(recompiled_apk_path, "r") as recompiled_apk, zipfile.ZipFile(
                 staged_apk_path, "w"
@@ -859,7 +859,18 @@ def restore_original_dex(apk_path, recompiled_apk_path, modified_dex_number):
 
             shutil.move(str(staged_apk_path), str(recompiled_apk_path))
             logger.info("Successfully replaced dex files in the recompiled APK")
-    except (OSError, zipfile.BadZipFile, KeyError) as e:
+    except (
+        OSError,
+        zipfile.BadZipFile,
+        zipfile.LargeZipFile,
+        NotImplementedError,
+        RuntimeError,
+        KeyError,
+    ) as e:
+        # Restoring the dex files is best effort: apktool has already produced a
+        # working APK, so a failure here is reported and the run carries on.
+        # zipfile raises NotImplementedError for compression methods it cannot
+        # read, which must not take the whole command down.
         logger.error("Failed to copy original dex files: %s", str(e))
 
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -22,6 +22,7 @@ import zipfile
 from shutil import which
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 import click
 from androguard.core.apk import APK
 from .apk_utils import get_main_activity
@@ -632,10 +633,10 @@ class GadgetSource:
         github_repo (str): repository given with --github-repo
     """
 
-    custom_gadget_name: str = None
-    custom_gadget_path: str = None
-    frida_version: str = None
-    github_repo: str = None
+    custom_gadget_name: Optional[str] = None
+    custom_gadget_path: Optional[str] = None
+    frida_version: Optional[str] = None
+    github_repo: Optional[str] = None
 
 
 # The parameters mirror the CLI flags that reach the injection step
@@ -1117,7 +1118,8 @@ def wrap_js_file(js: str, js_delay: int) -> str:
         temp_dir = tempfile.mkdtemp(prefix="frida-gadget-")
         atexit.register(shutil.rmtree, temp_dir, True)
         temp_js = Path(temp_dir).joinpath("wrapped.js")
-        temp_js.write_text(wrapped_content, encoding="utf-8")
+        with open(temp_js, "w", encoding="utf-8") as wrapped_file:
+            wrapped_file.write(wrapped_content)
     except (OSError, UnicodeDecodeError) as e:
         logger.error("Failed to process JavaScript file: %s", str(e))
         sys.exit(-1)
@@ -1232,7 +1234,8 @@ def wrap_js_with_timeout(js_content: str, delay: int) -> str:
     help="Show the version and exit.",
 )
 @click.argument("apk_path", type=click.Path(exists=True), required=True)
-def run(  # NOSONAR: one parameter per CLI flag
+# One parameter per CLI flag, so the count is dictated by the options above
+def run(  # NOSONAR
     apk_path: str,
     arch: str,
     config: str,

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -859,18 +859,11 @@ def restore_original_dex(apk_path, recompiled_apk_path, modified_dex_number):
 
             shutil.move(str(staged_apk_path), str(recompiled_apk_path))
             logger.info("Successfully replaced dex files in the recompiled APK")
-    except (
-        OSError,
-        zipfile.BadZipFile,
-        zipfile.LargeZipFile,
-        NotImplementedError,
-        RuntimeError,
-        KeyError,
-    ) as e:
+    except (OSError, zipfile.BadZipFile, zipfile.LargeZipFile, RuntimeError, KeyError) as e:
         # Restoring the dex files is best effort: apktool has already produced a
         # working APK, so a failure here is reported and the run carries on.
-        # zipfile raises NotImplementedError for compression methods it cannot
-        # read, which must not take the whole command down.
+        # RuntimeError covers the NotImplementedError zipfile raises for
+        # compression methods it cannot read, which must not take the run down.
         logger.error("Failed to copy original dex files: %s", str(e))
 
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -1,5 +1,4 @@
-"""
-Frida Gadget Injector for Android APK
+"""Frida Gadget Injector for Android APK.
 
 This script allows you to inject the Frida gadget library into an Android APK.
 It provides various functionalities including:
@@ -10,7 +9,6 @@ It provides various functionalities including:
 - Recompiling the APK
 - Optionally signing the APK using uber-apk-signer
 """
-
 import os
 import sys
 import atexit
@@ -41,7 +39,7 @@ APKTOOL = which("apktool")
 
 
 def get_decompiled_path(apk_path: Path) -> Path:
-    """Build the path apktool decompiles the APK into
+    """Build the path apktool decompiles the APK into.
 
     Args:
         apk_path (Path): path of apk file
@@ -58,7 +56,7 @@ def get_decompiled_path(apk_path: Path) -> Path:
 
 
 def is_reusable_decompile_dir(path: Path) -> bool:
-    """Check whether a decompile directory can be safely removed
+    """Check whether a decompile directory can be safely removed.
 
     Only empty directories and previous apktool outputs are reusable, so an
     unrelated directory that happens to share the APK name is never deleted.
@@ -86,7 +84,7 @@ def is_reusable_decompile_dir(path: Path) -> bool:
 
 
 def resolve_apktool(apktool_path: str = None) -> str:
-    """Work out the apktool command to run
+    """Work out the apktool command to run.
 
     Args:
         apktool_path (str): path or command given with --apktool-path
@@ -123,15 +121,13 @@ def resolve_apktool(apktool_path: str = None) -> str:
 
 
 def run_apktool(option: list, apk_path: str, apktool: str = None):
-    """Run apktool with option
+    """Run apktool with option.
 
     Args:
         option (list|str): option of apktool
         apk_path (str): path of apk file
         apktool (str): command to invoke apktool with, defaults to the one on PATH
-
     """
-
     pipe = subprocess.PIPE
     cmd = (apktool or APKTOOL).split() + option + [apk_path]
     with subprocess.Popen(
@@ -165,7 +161,7 @@ def download_gadget(
     custom_gadget_path: str = None,
     github_repo: str = None,
 ):
-    """Download the frida gadget library or use a custom file
+    """Download the frida gadget library or use a custom file.
 
     Args:
         arch (str): architecture of the device
@@ -217,7 +213,7 @@ def download_gadget(
 
 
 def download_signer():
-    """Download the Uber Apk Signer"""
+    """Download the Uber Apk Signer."""
     signer_github = UberApkSignerGithub()
     assets = signer_github.get_assets()
     file = f"uber-apk-signer-{signer_github.signer_version}.jar"
@@ -230,7 +226,7 @@ def download_signer():
 
 
 def find_activity_smali(decompiled_path, main_activity):
-    """Locate the smali file of an activity across the smali_classes* trees
+    """Locate the smali file of an activity across the smali_classes* trees.
 
     Args:
         decompiled_path (Path): decompiled path of apk file
@@ -264,7 +260,7 @@ def find_activity_smali(decompiled_path, main_activity):
 
 
 def insert_load_library_call(text: list, load_library_name: str) -> bool:
-    """Insert the loadLibrary call into the first usable entrypoint
+    """Insert the loadLibrary call into the first usable entrypoint.
 
     Args:
         text (list): lines of the smali file, modified in place
@@ -303,7 +299,7 @@ def insert_load_library_call(text: list, load_library_name: str) -> bool:
 
 
 def insert_loadlibary(decompiled_path, main_activity, load_library_name):
-    """Inject loadlibary code to main activity
+    """Inject loadlibary code to main activity.
 
     Args:
         decompiled_path (str): decomplied path of apk file
@@ -340,7 +336,7 @@ def insert_loadlibary(decompiled_path, main_activity, load_library_name):
     return target_smali_class_number
 
 def modify_manifest(decompiled_path):
-    """Modify manifest permissions
+    """Modify manifest permissions.
 
     Args:
         decompiled_path (str): decomplied path of apk file
@@ -367,7 +363,7 @@ def modify_manifest(decompiled_path):
 
 
 def detect_apk_architectures(decompiled_path):
-    """Detect architectures from the APK's lib directory
+    """Detect architectures from the APK's lib directory.
 
     Args:
         decompiled_path (str): decompiled path of apk file
@@ -413,7 +409,7 @@ ARCH_DIRNAMES = {
 
 
 def resolve_main_activity(apk: APK, main_activity: str = None) -> str:
-    """Work out which activity the loadLibrary call goes into
+    """Work out which activity the loadLibrary call goes into.
 
     Args:
         apk (APK): parsed apk file
@@ -449,7 +445,7 @@ def resolve_main_activity(apk: APK, main_activity: str = None) -> str:
 
 
 def resolve_gadget_name(gadget_path: str, custom_gadget_name: str, arch: str) -> str:
-    """Decide the file name the gadget is stored under inside the APK
+    """Decide the file name the gadget is stored under inside the APK.
 
     Args:
         gadget_path (str): path of the downloaded or supplied gadget
@@ -475,7 +471,7 @@ def resolve_gadget_name(gadget_path: str, custom_gadget_name: str, arch: str) ->
 
 
 def prepare_lib_dir(decompiled_path: Path, current_arch: str) -> Path:
-    """Create the lib/<abi> directory the gadget is copied into
+    """Create the lib/<abi> directory the gadget is copied into.
 
     Args:
         decompiled_path (Path): decompiled path of apk file
@@ -496,7 +492,7 @@ def prepare_lib_dir(decompiled_path: Path, current_arch: str) -> Path:
 
 
 def load_config_data(config: str) -> dict:
-    """Read a gadget config file and check it declares an interaction
+    """Read a gadget config file and check it declares an interaction.
 
     Args:
         config (str): path of the config file
@@ -519,7 +515,7 @@ def load_config_data(config: str) -> dict:
 
 
 def warn_config_without_script(config: str):
-    """Explain what a config without --js means for the resulting APK
+    """Explain what a config without --js means for the resulting APK.
 
     Args:
         config (str): path of the config file
@@ -552,7 +548,7 @@ def warn_config_without_script(config: str):
 def write_gadget_config(
     config: str, js: str, lib_arch_dir: Path, load_library_name: str, upload_files: dict
 ):
-    """Write the gadget's config file next to the library
+    """Write the gadget's config file next to the library.
 
     Args:
         config (str): path given with --config
@@ -592,7 +588,7 @@ def write_gadget_config(
 
 
 def upload_gadget_files(upload_files: dict, lib_arch_dir: Path, load_library_name: str):
-    """Copy the config and script files into the APK's lib directory
+    """Copy the config and script files into the APK's lib directory.
 
     Args:
         upload_files (dict): file type to source path
@@ -624,7 +620,7 @@ def upload_gadget_files(upload_files: dict, lib_arch_dir: Path, load_library_nam
 
 @dataclass
 class GadgetSource:
-    """Where the gadget library comes from and what it is called
+    """Where the gadget library comes from and what it is called.
 
     Attributes:
         custom_gadget_name (str): name given with --custom-gadget-name
@@ -652,7 +648,7 @@ def inject_gadget_into_apk(
     js: str = None,
     gadget_source: "GadgetSource" = None,
 ) -> int:
-    """Inject frida gadget into an APK
+    """Inject frida gadget into an APK.
 
     Args:
         apk (APK): path of apk file
@@ -709,7 +705,7 @@ def inject_gadget_into_apk(
 
 
 def stdin_is_interactive():
-    """Check whether a child process could prompt on this stdin
+    """Check whether a child process could prompt on this stdin.
 
     Returns:
         bool: True if stdin is attached to a terminal
@@ -721,7 +717,7 @@ def stdin_is_interactive():
 
 
 def redact_passwords(cmd: list):
-    """Hide keystore passwords in a command line before it is reported
+    """Hide keystore passwords in a command line before it is reported.
 
     Args:
         cmd (list): command line of the signer
@@ -744,7 +740,7 @@ def sign_apk(
     ks_key_pass: str = None,
     ks_pass: str = None,
 ):
-    """Run uber apk signer with option
+    """Run uber apk signer with option.
 
     Args:
         apk_path (str): path of apk file
@@ -814,7 +810,7 @@ def sign_apk(
 
 
 def restore_original_dex(apk_path, recompiled_apk_path, modified_dex_number):
-    """Put the original dex files back into the recompiled APK
+    """Put the original dex files back into the recompiled APK.
 
     apktool reassembles every dex file, which can change classes it was never
     asked to touch. Only the dex holding the patched main activity has to come
@@ -927,7 +923,7 @@ def detect_adb_arch():
 
 
 def print_version(ctx, _, value):
-    """Print version and exit"""
+    """Print version and exit."""
     if not value or ctx.resilient_parsing:
         return
     print(f"frida-gadget version {__version__}")
@@ -938,7 +934,7 @@ SUPPORTED_ARCHS = ["arm", "arm64", "x86", "x86_64"]
 
 
 def log_target_arch(arch: str):
-    """Report the architecture the gadget will be built for
+    """Report the architecture the gadget will be built for.
 
     Args:
         arch (str): normalized architecture name
@@ -958,7 +954,7 @@ def log_target_arch(arch: str):
 
 
 def validate_arch(arch: str) -> str:
-    """Check the architecture is one we can download a gadget for
+    """Check the architecture is one we can download a gadget for.
 
     Args:
         arch (str): normalized architecture name
@@ -981,7 +977,7 @@ def validate_arch(arch: str) -> str:
 
 
 def validate_input_files(js: str, config: str):
-    """Check the files given with --js and --config are usable
+    """Check the files given with --js and --config are usable.
 
     Args:
         js (str): path given with --js
@@ -1007,7 +1003,7 @@ def validate_input_files(js: str, config: str):
 
 
 def prepare_decompile_dir(decompiled_path: Path):
-    """Make sure the decompile target is an empty directory we may write to
+    """Make sure the decompile target is an empty directory we may write to.
 
     Args:
         decompiled_path (Path): the decompile directory
@@ -1030,7 +1026,7 @@ def prepare_decompile_dir(decompiled_path: Path):
 def build_decompile_options(
     decompiled_path: Path, force_manifest: bool, no_res: bool, decompile_opts: str
 ):
-    """Assemble the apktool decode command line
+    """Assemble the apktool decode command line.
 
     Args:
         decompiled_path (Path): where apktool should write the decompiled APK
@@ -1059,7 +1055,7 @@ def build_decompile_options(
 
 
 def normalize_arch(arch: str, skip_decompile: bool) -> str:
-    """Turn the --arch value into one of the names used internally
+    """Turn the --arch value into one of the names used internally.
 
     Args:
         arch (str): value given with --arch, None to auto-detect over ADB
@@ -1083,7 +1079,7 @@ def normalize_arch(arch: str, skip_decompile: bool) -> str:
 
 
 def wrap_js_file(js: str, js_delay: int) -> str:
-    """Write a delayed copy of the script and return its path
+    """Write a delayed copy of the script and return its path.
 
     Args:
         js (str): path given with --js
@@ -1129,7 +1125,7 @@ def wrap_js_file(js: str, js_delay: int) -> str:
 
 
 def wrap_js_with_timeout(js_content: str, delay: int) -> str:
-    """Wrap JavaScript content with setTimeout
+    """Wrap JavaScript content with setTimeout.
 
     Args:
         js_content (str): Original JavaScript content
@@ -1260,7 +1256,7 @@ def run(  # NOSONAR
     ks_pass: str,
     github_repo: str,
 ):
-    """Patch an APK with the Frida gadget library"""
+    """Patch an APK with the Frida gadget library."""
     apk_path = Path(apk_path)
 
     logger.info("APK: '%s'", apk_path)

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -12,7 +12,6 @@ It provides various functionalities including:
 """
 
 import os
-import re
 import sys
 import atexit
 import shutil
@@ -21,6 +20,7 @@ import json
 import tempfile
 import zipfile
 from shutil import which
+from dataclasses import dataclass
 from pathlib import Path
 import click
 from androguard.core.apk import APK
@@ -84,31 +84,71 @@ def is_reusable_decompile_dir(path: Path) -> bool:
     )
 
 
-def run_apktool(option: list, apk_path: str):
+def resolve_apktool(apktool_path: str = None) -> str:
+    """Work out the apktool command to run
+
+    Args:
+        apktool_path (str): path or command given with --apktool-path
+
+    Returns:
+        str: the command to invoke apktool with
+
+    Raises:
+        FileNotFoundError: apktool is neither given nor on PATH
+    """
+    if not apktool_path:
+        if not APKTOOL:
+            raise FileNotFoundError(
+                "apktool not found. Please install apktool and add it to your PATH environment.\n"
+                "For macOS: brew install apktool\n"
+                "For Windows: Download from https://ibotpeaches.github.io/Apktool/install/\n"
+                "For Linux: sudo apt-get install apktool\n"
+                "After installation, you may need to restart your terminal."
+            )
+        return APKTOOL
+
+    apktool_parts = apktool_path.split()
+    apktool_binary = apktool_parts[-1]
+    if not Path(apktool_binary).exists():
+        logger.error("The specified apktool path does not exist: %s", apktool_binary)
+        sys.exit(-1)
+
+    if len(apktool_parts) > 1:
+        logger.info("Using custom apktool command: '%s'", apktool_path)
+    else:
+        logger.info("Using custom apktool path: '%s'", apktool_path)
+
+    return apktool_path
+
+
+def run_apktool(option: list, apk_path: str, apktool: str = None):
     """Run apktool with option
 
     Args:
         option (list|str): option of apktool
         apk_path (str): path of apk file
+        apktool (str): command to invoke apktool with, defaults to the one on PATH
 
     """
 
     pipe = subprocess.PIPE
-    cmd = APKTOOL.split() + option + [apk_path]
+    cmd = (apktool or APKTOOL).split() + option + [apk_path]
     with subprocess.Popen(
         cmd, stdin=pipe, stdout=sys.stdout, stderr=sys.stderr
     ) as process:
         process.communicate(b"\n")
         if process.returncode != 0:
-            recommend_options = ["--no-res", "--use-aapt2"]
-            for opt in recommend_options:
-                if opt in option:
-                    recommend_options.remove(opt)
+            # Suggest only the options that are not in use yet. Removing from the
+            # list while iterating over it used to skip the second entry.
+            recommend_options = [
+                opt for opt in ("--no-res", "--use-aapt2") if opt not in option
+            ]
 
             logger.error(
                 "It looks like you're having trouble with apktool.\n"
                 "Consider trying the '%s' options, or if you'd prefer more control,\n"
-                "you can manually specify apktool settings using ['--decompile-opts', '--recompile-opts', '--apktool-path'].",
+                "you can manually specify apktool settings using "
+                "['--decompile-opts', '--recompile-opts', '--apktool-path'].",
                 recommend_options,
             )
 
@@ -188,6 +228,79 @@ def download_signer():
     return signer_github.download_signer_jar(assets, signer_path)
 
 
+def find_activity_smali(decompiled_path, main_activity):
+    """Locate the smali file of an activity across the smali_classes* trees
+
+    Args:
+        decompiled_path (Path): decompiled path of apk file
+        main_activity (str): activity class name
+
+    Returns:
+        tuple: the smali file path, and the smali_classes<N> number it sits in
+               (None for the plain 'smali' directory)
+
+    Raises:
+        FileNotFoundError: the activity has no smali file
+    """
+    target_relative_path = main_activity.replace(".", os.sep) + ".smali"
+
+    for directory in sorted(decompiled_path.iterdir()):
+        if not directory.is_dir() or not directory.name.startswith("smali"):
+            continue
+
+        target_smali = directory.joinpath(target_relative_path)
+        if not target_smali.exists():
+            continue
+
+        class_number = None
+        if directory.name.startswith("smali_classes"):
+            class_number = int(directory.name.split("smali_classes")[1])
+        return target_smali, class_number
+
+    raise FileNotFoundError(
+        f"The smali file for '{main_activity}' was not found under {decompiled_path}."
+    )
+
+
+def insert_load_library_call(text: list, load_library_name: str) -> bool:
+    """Insert the loadLibrary call into the first usable entrypoint
+
+    Args:
+        text (list): lines of the smali file, modified in place
+        load_library_name (str): name passed to System.loadLibrary
+
+    Returns:
+        bool: True when the call was inserted
+    """
+    if load_library_name.startswith("lib"):
+        load_library_name = load_library_name[3:]
+
+    for entrypoint in (" onCreate(", "<init>"):
+        for idx, line in enumerate(text):
+            if not line.strip().startswith(".method") or entrypoint not in line:
+                continue
+
+            # The call needs a register, which only a method declaring .locals has
+            if idx + 1 >= len(text):
+                continue
+
+            declaration = text[idx + 1]
+            if ".locals" not in declaration:
+                continue
+
+            # Increase the number of locals 0 to 1
+            text[idx + 1] = declaration.replace(".locals 0", ".locals 1")
+            text.insert(
+                idx + 2,
+                "    invoke-static {v0}, "
+                "Ljava/lang/System;->loadLibrary(Ljava/lang/String;)V",
+            )
+            text.insert(idx + 2, f'    const-string v0, "{load_library_name}"')
+            return True
+
+    return False
+
+
 def insert_loadlibary(decompiled_path, main_activity, load_library_name):
     """Inject loadlibary code to main activity
 
@@ -195,61 +308,22 @@ def insert_loadlibary(decompiled_path, main_activity, load_library_name):
         decompiled_path (str): decomplied path of apk file
         main_activity (str): main activity of apk file
         load_library_name (str): name of load library
+
+    Returns:
+        int: the smali_classes<N> number the patched activity sits in
     """
     logger.debug("Searching for the main activity in the smali files")
-    target_smali = None
-    target_smali_class_number = None
-
-    target_relative_path = main_activity.replace(".", os.sep)
-    for directory in decompiled_path.iterdir():
-        if directory.is_dir() and directory.name.startswith("smali"):
-            target_smali = directory.joinpath(target_relative_path + ".smali")
-            if target_smali.exists():
-                if directory.name.startswith("smali_classes"):
-                    target_smali_class_number = int(directory.name.split("smali_classes")[1])
-                break
-
-    if not target_smali or not target_smali.exists():
-        raise FileNotFoundError(f"The target class file {target_smali} was not found.")
+    target_smali, target_smali_class_number = find_activity_smali(
+        decompiled_path, main_activity
+    )
 
     logger.debug("Found the main activity at '%s'", str(target_smali))
-    text = target_smali.read_text()
-
+    text = target_smali.read_text(encoding="utf-8")
     text = text.replace("invoke-virtual {v0, v1}, Ljava/lang/Runtime;->exit(I)V", "")
     text = text.split("\n")
 
     logger.debug("Locating the entrypoint method and injecting the loadLibrary code")
-    status = False
-    entrypoints = [" onCreate(", "<init>"]
-    for entrypoint in entrypoints:
-        idx = 0
-        while idx != len(text):
-            line = text[idx].strip()
-            if line.startswith(".method") and entrypoint in line:
-                if ".locals" not in text[idx + 1]:
-                    idx += 1
-                    continue
-                else:
-                    # Increase the number of locals 0 to 1
-                    if ".locals 0" in text[idx + 1]:
-                        text[idx + 1] = text[idx + 1].replace(".locals 0", ".locals 1")
-
-                if load_library_name.startswith("lib"):
-                    load_library_name = load_library_name[3:]
-                text.insert(
-                    idx + 2,
-                    "    invoke-static {v0}, "
-                    "Ljava/lang/System;->loadLibrary(Ljava/lang/String;)V",
-                )
-                text.insert(idx + 2, f"    const-string v0, " f'"{load_library_name}"')
-                status = True
-                break
-            idx += 1
-
-        if status:
-            break
-
-    if not status:
+    if not insert_load_library_call(text, load_library_name):
         logger.error("Cannot find the appropriate position in the main activity.")
         logger.error(
             "Please report the issue at %s with the following information:",
@@ -261,7 +335,7 @@ def insert_loadlibary(decompiled_path, main_activity, load_library_name):
         sys.exit(-1)
 
     # Replace the smali file with the new one
-    target_smali.write_text("\n".join(text))
+    target_smali.write_text("\n".join(text), encoding="utf-8")
     return target_smali_class_number
 
 def modify_manifest(decompiled_path):
@@ -329,6 +403,243 @@ def detect_apk_architectures(decompiled_path):
     return detected_archs
 
 
+ARCH_DIRNAMES = {
+    "arm": "armeabi-v7a",
+    "x86": "x86",
+    "arm64": "arm64-v8a",
+    "x86_64": "x86_64",
+}
+
+
+def resolve_main_activity(apk: APK, main_activity: str = None) -> str:
+    """Work out which activity the loadLibrary call goes into
+
+    Args:
+        apk (APK): parsed apk file
+        main_activity (str): activity given with --main-activity
+
+    Returns:
+        str: the activity class name
+    """
+    if main_activity:
+        return main_activity
+
+    main_activity = get_main_activity(apk)
+    if main_activity == -1:  # multiple main activities
+        sys.exit(-1)
+    if main_activity:
+        return main_activity
+
+    activities = apk.get_activities()
+    if len(activities) == 1:
+        logger.warning(
+            "The main activity was not found.\n"
+            "Using the first activity from the manifest file."
+        )
+        return activities[0]
+
+    logger.error(
+        "The main activity was not found.\n"
+        "Please specify the main activity using the --main-activity option.\n"
+        "Select the activity from %s",
+        activities,
+    )
+    sys.exit(-1)
+
+
+def resolve_gadget_name(gadget_path: str, custom_gadget_name: str, arch: str) -> str:
+    """Decide the file name the gadget is stored under inside the APK
+
+    Args:
+        gadget_path (str): path of the downloaded or supplied gadget
+        custom_gadget_name (str): name given with --custom-gadget-name
+        arch (str): the requested architecture, or 'multi-arch'
+
+    Returns:
+        str: the file name to use in lib/<abi>
+    """
+    if custom_gadget_name:
+        gadget_name = custom_gadget_name + ".so"
+        logger.info("Using custom gadget name: %s", gadget_name)
+        return gadget_name
+
+    if arch == "multi-arch":
+        # The downloaded file name carries the architecture, but a single
+        # loadLibrary call has to resolve inside every lib/<abi> directory
+        gadget_name = "libfrida-gadget.so"
+        logger.info("Using multi-arch gadget name: %s", gadget_name)
+        return gadget_name
+
+    return Path(gadget_path).name
+
+
+def prepare_lib_dir(decompiled_path: Path, current_arch: str) -> Path:
+    """Create the lib/<abi> directory the gadget is copied into
+
+    Args:
+        decompiled_path (Path): decompiled path of apk file
+        current_arch (str): architecture being injected
+
+    Returns:
+        Path: the lib/<abi> directory
+
+    Raises:
+        NotImplementedError: the architecture has no known ABI directory
+    """
+    if current_arch not in ARCH_DIRNAMES:
+        raise NotImplementedError(f"The architecture '{current_arch}' is not supported.")
+
+    lib_arch_dir = decompiled_path.joinpath("lib", ARCH_DIRNAMES[current_arch])
+    lib_arch_dir.mkdir(parents=True, exist_ok=True)
+    return lib_arch_dir
+
+
+def load_config_data(config: str) -> dict:
+    """Read a gadget config file and check it declares an interaction
+
+    Args:
+        config (str): path of the config file
+
+    Returns:
+        dict: the parsed config
+    """
+    with open(config, "r", encoding="utf-8") as f:
+        config_data = json.load(f)
+
+    if "interaction" not in config_data:
+        logger.error("The config file must contain an 'interaction' key.")
+        sys.exit(-1)
+
+    if "type" not in config_data["interaction"]:
+        logger.error("The config file must contain an 'interaction.type' key.")
+        sys.exit(-1)
+
+    return config_data
+
+
+def warn_config_without_script(config: str):
+    """Explain what a config without --js means for the resulting APK
+
+    Args:
+        config (str): path of the config file
+    """
+    logger.warning(
+        "The '%s' config file was provided without the script file.", config
+    )
+    logger.warning(
+        "To upload the script file to the APK, please provide the --js option."
+    )
+
+    config_data = load_config_data(config)
+    if config_data["interaction"]["type"] not in ("script", "script-directory"):
+        # 'listen' and 'connect' wait for a client instead of loading a script
+        return
+
+    if "path" not in config_data["interaction"]:
+        logger.error(
+            "The config file must contain a 'interaction.path' key with "
+            "'type: script' or 'type: script-directory'"
+        )
+        sys.exit(-1)
+
+    logger.warning(
+        "The script file must be located at '%s' on your Android device",
+        config_data["interaction"]["path"],
+    )
+
+
+def write_gadget_config(
+    config: str, js: str, lib_arch_dir: Path, load_library_name: str, upload_files: dict
+):
+    """Write the gadget's config file next to the library
+
+    Args:
+        config (str): path given with --config
+        js (str): path given with --js
+        lib_arch_dir (Path): the lib/<abi> directory
+        load_library_name (str): name passed to System.loadLibrary
+        upload_files (dict): files still to copy, the config is removed from it
+                             once it has been written here
+    """
+    script_path = f"{load_library_name}.script.so"
+
+    if js and config:
+        config_data = load_config_data(config)
+        if "path" in config_data["interaction"]:
+            logger.debug(
+                "Updating the script path in '%s' from '%s' to '%s'",
+                config,
+                config_data["interaction"]["path"],
+                script_path,
+            )
+        config_data["interaction"]["path"] = script_path
+    elif js:
+        config_data = {"interaction": {"type": "script", "path": script_path}}
+    else:
+        if config:
+            warn_config_without_script(config)
+        return
+
+    config_name = f"{load_library_name}.config.so"
+    contents = json.dumps(config_data, indent=4)
+    with open(lib_arch_dir.joinpath(config_name), "w", encoding="utf-8") as f:
+        f.write(contents)
+
+    logger.debug("Created the config file: %s", config_name)
+    logger.debug(contents)
+    del upload_files["config"]
+
+
+def upload_gadget_files(upload_files: dict, lib_arch_dir: Path, load_library_name: str):
+    """Copy the config and script files into the APK's lib directory
+
+    Args:
+        upload_files (dict): file type to source path
+        lib_arch_dir (Path): the lib/<abi> directory
+        load_library_name (str): name passed to System.loadLibrary
+    """
+    for file_type, file_path in upload_files.items():
+        if not file_path:
+            continue
+
+        file_path = Path(file_path)
+        if not file_path.exists():
+            logger.error("Frida %s file not found: %s", file_type, file_path)
+            sys.exit(-1)
+
+        target_name = f"{load_library_name}.{file_type}.so"
+        if file_path.name == target_name:
+            logger.debug("Uploading Frida %s file: %s", file_type, file_path.name)
+        else:
+            logger.debug(
+                "Renaming and uploading Frida %s file: %s -> %s",
+                file_type,
+                file_path.name,
+                target_name,
+            )
+
+        shutil.copy(file_path, lib_arch_dir.joinpath(target_name))
+
+
+@dataclass
+class GadgetSource:
+    """Where the gadget library comes from and what it is called
+
+    Attributes:
+        custom_gadget_name (str): name given with --custom-gadget-name
+        custom_gadget_path (str): path given with --custom-gadget-path
+        frida_version (str): version given with --frida-version
+        github_repo (str): repository given with --github-repo
+    """
+
+    custom_gadget_name: str = None
+    custom_gadget_path: str = None
+    frida_version: str = None
+    github_repo: str = None
+
+
+# The parameters mirror the CLI flags that reach the injection step
+# pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
 def inject_gadget_into_apk(
     apk_path: str,
     arch: str,
@@ -338,10 +649,7 @@ def inject_gadget_into_apk(
     main_activity: str = None,
     config: str = None,
     js: str = None,
-    custom_gadget_name: str = None,
-    custom_gadget_path: str = None,
-    frida_version: str = None,
-    github_repo: str = None,
+    gadget_source: "GadgetSource" = None,
 ) -> int:
     """Inject frida gadget into an APK
 
@@ -355,6 +663,7 @@ def inject_gadget_into_apk(
         NotImplementedError: not implemented
     """
     apk = APK(apk_path)
+    gadget_source = gadget_source or GadgetSource()
 
     # Handle 'multi-arch' option
     if arch == "multi-arch":
@@ -365,27 +674,7 @@ def inject_gadget_into_apk(
     else:
         archs = [arch]
 
-    # Get main activity if not provided
-    if not main_activity:
-        main_activity = get_main_activity(apk)
-        if main_activity == -1:  # multiple main activities
-            sys.exit(-1)
-
-    if not main_activity:
-        if len(apk.get_activities()) == 1:
-            logger.warning(
-                "The main activity was not found.\n"
-                "Using the first activity from the manifest file."
-            )
-            main_activity = apk.get_activities()[0]
-        else:
-            logger.error(
-                "The main activity was not found.\n"
-                "Please specify the main activity using the --main-activity option.\n"
-                "Select the activity from %s",
-                apk.get_activities(),
-            )
-            sys.exit(-1)
+    main_activity = resolve_main_activity(apk, main_activity)
 
     # Apply permission to android manifest
     if not no_res or force_manifest:
@@ -393,41 +682,15 @@ def inject_gadget_into_apk(
 
     for current_arch in archs:
         gadget_path = download_gadget(
-            current_arch, frida_version, custom_gadget_path, github_repo
+            current_arch,
+            gadget_source.frida_version,
+            gadget_source.custom_gadget_path,
+            gadget_source.github_repo,
         )
-        gadget_name = Path(gadget_path).name
-
-        # Apply custom gadget name if provided
-        if custom_gadget_name:
-            custom_gadget_name_with_ext = custom_gadget_name + ".so"
-            logger.info("Using custom gadget name: %s", custom_gadget_name_with_ext)
-            gadget_name = custom_gadget_name_with_ext
-        if arch == "multi-arch":
-            # TODO: custom gadget name for multi-arch
-            gadget_name = "libfrida-gadget.so"
-            logger.info("Using multi-arch gadget name: %s", gadget_name)
-
-        # Save the first gadget info for loadLibrary
-        # Copy the frida gadget library to the lib directory
-        lib = decompiled_path.joinpath("lib")
-        if not lib.exists():
-            lib.mkdir()
-
-        arch_dirnames = {
-            "arm": "armeabi-v7a",
-            "x86": "x86",
-            "arm64": "arm64-v8a",
-            "x86_64": "x86_64",
-        }
-        if current_arch not in arch_dirnames:
-            raise NotImplementedError(
-                f"The architecture '{current_arch}' is not supported."
-            )
-
-        arch_dirname = arch_dirnames[current_arch]
-        lib_arch_dir = lib.joinpath(arch_dirname)
-        if not lib_arch_dir.exists():
-            lib_arch_dir.mkdir()
+        gadget_name = resolve_gadget_name(
+            gadget_path, gadget_source.custom_gadget_name, arch
+        )
+        lib_arch_dir = prepare_lib_dir(decompiled_path, current_arch)
 
         lib_library_name = gadget_name
         if not lib_library_name.startswith("lib"):
@@ -438,101 +701,8 @@ def inject_gadget_into_apk(
         upload_files = {"config": config, "script": js}
         load_library_name = lib_library_name[:-3]
 
-        if js and config:
-            with open(config, "r") as f:
-                contents = f.read()
-                config_data = json.loads(contents)
-                if "interaction" not in config_data:
-                    logger.error("The config file must contain an 'interaction' key.")
-                    sys.exit(-1)
-                if "type" not in config_data["interaction"]:
-                    logger.error(
-                        "The config file must contain an 'interaction.type' key."
-                    )
-                    sys.exit(-1)
-                if "path" in config_data["interaction"]:
-                    logger.debug(
-                        "Updating the script path in '%s' from '%s' to 'lib%s.script.so'",
-                        config,
-                        config_data["interaction"]["path"],
-                        load_library_name,
-                    )
-                config_data["interaction"]["path"] = f"{load_library_name}.script.so"
-                with open(
-                    lib_arch_dir.joinpath(f"{load_library_name}.config.so"), "w"
-                ) as f:
-                    f.write(json.dumps(config_data, indent=4))
-                del upload_files["config"]
-        elif js:
-            config_name = f"{load_library_name}.config.so"
-            with open(lib_arch_dir.joinpath(config_name), "w") as f:
-                contents = (
-                    """\
-                \r{
-                \r    "interaction": {
-                \r        "type": "script",
-                \r        "path": \""""
-                    + load_library_name
-                    + """.script.so"
-                \r    }
-                \r}
-                """
-                )
-                f.write(contents)
-                logger.debug("Created the default config file: %s", config_name)
-                logger.debug(contents)
-            del upload_files["config"]
-        elif config:
-            logger.warning(
-                "The '%s' config file was provided without the script file.", config
-            )
-            logger.warning(
-                "To upload the script file to the APK, please provide the --js option."
-            )
-            with open(config, "r") as f:
-                contents = f.read()
-                config_data = json.loads(contents)
-                if "interaction" not in config_data:
-                    logger.error("The config file must contain an 'interaction' key.")
-                    sys.exit(-1)
-                if "type" not in config_data["interaction"]:
-                    logger.error(
-                        "The config file must contain an 'interaction.type' key."
-                    )
-                    sys.exit(-1)
-                if config_data["interaction"]["type"] in (
-                    "script-directory", "script"
-                ):
-                    if "path" not in config_data["interaction"]:
-                        logger.error(
-                            "The config file must contain a 'interaction.path' key with 'type: script' or 'type: script-directory'"
-                        )
-                        sys.exit(-1)
-                    logger.warning(
-                        "The script file must be located at '%s' on your Android device",
-                        config_data["interaction"]["path"],
-                    )
-
-        for file_type, file_path in upload_files.items():
-            if file_path:
-                file_path = Path(file_path)
-                if not file_path.exists():
-                    logger.error("Frida %s file not found: %s", file_type, file_path)
-                    sys.exit(-1)
-                else:
-                    target_name = f"{load_library_name}.{file_type}.so"
-                    if file_path.name == target_name:
-                        logger.debug(
-                            "Uploading Frida %s file: %s", file_type, file_path.name
-                        )
-                    else:
-                        logger.debug(
-                            "Renaming and uploading Frida %s file: %s -> %s",
-                            file_type,
-                            file_path.name,
-                            target_name,
-                        )
-                    shutil.copy(file_path, lib_arch_dir.joinpath(target_name))
+        write_gadget_config(config, js, lib_arch_dir, load_library_name, upload_files)
+        upload_gadget_files(upload_files, lib_arch_dir, load_library_name)
 
     return insert_loadlibary(decompiled_path, main_activity, load_library_name)
 
@@ -642,6 +812,60 @@ def sign_apk(
                 logger.info("APK signing finished: %s", apk_path)
 
 
+def restore_original_dex(apk_path, recompiled_apk_path, modified_dex_number):
+    """Put the original dex files back into the recompiled APK
+
+    apktool reassembles every dex file, which can change classes it was never
+    asked to touch. Only the dex holding the patched main activity has to come
+    from the rebuild; the rest are copied over from the original APK.
+
+    Args:
+        apk_path (Path): path of the original apk file
+        recompiled_apk_path (Path): path of the apk apktool produced
+        modified_dex_number (int): smali_classes<N> the main activity lives in
+    """
+    logger.debug(
+        "Copying original dex files (except modified one %s) to the recompiled APK",
+        modified_dex_number,
+    )
+
+    modified_dex_filename = (
+        f"classes{modified_dex_number}.dex"
+        if modified_dex_number and modified_dex_number > 1
+        else "classes.dex"
+    )
+
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            with zipfile.ZipFile(apk_path, "r") as original_apk:
+                original_apk.extractall(temp_dir_path)
+
+            # Built inside the temporary directory so a failure cannot leave a
+            # stray file behind, and the move below stays on one filesystem
+            staged_apk_path = temp_dir_path.joinpath("repacked.apk")
+            with zipfile.ZipFile(recompiled_apk_path, "r") as recompiled_apk, zipfile.ZipFile(
+                staged_apk_path, "w"
+            ) as new_apk:
+                for item in recompiled_apk.infolist():
+                    is_dex = item.filename.startswith("classes") and item.filename.endswith(
+                        ".dex"
+                    )
+                    if is_dex and item.filename != modified_dex_filename:
+                        dex_file = temp_dir_path.joinpath(item.filename)
+                        new_apk.write(str(dex_file), dex_file.name)
+                        continue
+
+                    if item.filename == modified_dex_filename:
+                        logger.debug("Copying %s from recompiled APK", item.filename)
+                    new_apk.writestr(item, recompiled_apk.read(item.filename))
+
+            shutil.move(str(staged_apk_path), str(recompiled_apk_path))
+            logger.info("Successfully replaced dex files in the recompiled APK")
+    except (OSError, zipfile.BadZipFile, KeyError) as e:
+        logger.error("Failed to copy original dex files: %s", str(e))
+
+
 def detect_adb_arch():
     """Detect the architecture of the currently connected device via ADB.
 
@@ -671,7 +895,8 @@ def detect_adb_arch():
             arch = stdout.decode().strip()
             if not arch:
                 logger.warning(
-                    "Architecture detection failed: no output received. Falling back to default: %s",
+                    "Architecture detection failed: no output received. "
+                    "Falling back to default: %s",
                     default_arch,
                 )
                 return default_arch
@@ -690,9 +915,10 @@ def detect_adb_arch():
             default_arch,
         )
         return default_arch
-    except Exception as e:
+    except (OSError, ValueError, subprocess.SubprocessError) as e:
         logger.warning(
-            "An unexpected error occurred during architecture detection: %s. Falling back to default: %s",
+            "An unexpected error occurred during architecture detection: %s. "
+            "Falling back to default: %s",
             str(e),
             default_arch,
         )
@@ -705,6 +931,199 @@ def print_version(ctx, _, value):
         return
     print(f"frida-gadget version {__version__}")
     ctx.exit()
+
+
+SUPPORTED_ARCHS = ["arm", "arm64", "x86", "x86_64"]
+
+
+def log_target_arch(arch: str):
+    """Report the architecture the gadget will be built for
+
+    Args:
+        arch (str): normalized architecture name
+    """
+    if arch == "multi-arch":
+        logger.info(
+            "Gadget Architecture(--arch): %s (will inject for all architectures found in APK)",
+            arch,
+        )
+        return
+
+    logger.info(
+        "Gadget Architecture(--arch): %s%s",
+        arch,
+        "(default)" if arch == "arm64" else "",
+    )
+
+
+def validate_arch(arch: str) -> str:
+    """Check the architecture is one we can download a gadget for
+
+    Args:
+        arch (str): normalized architecture name
+
+    Returns:
+        str: the architecture, lowercased
+    """
+    if arch == "multi-arch":
+        return arch
+
+    arch = arch.lower()
+    if arch not in SUPPORTED_ARCHS:
+        logger.error(
+            "The --arch option only supports the following architectures: %s, multi-arch",
+            ", ".join(SUPPORTED_ARCHS),
+        )
+        sys.exit(-1)
+
+    return arch
+
+
+def validate_input_files(js: str, config: str):
+    """Check the files given with --js and --config are usable
+
+    Args:
+        js (str): path given with --js
+        config (str): path given with --config
+    """
+    if js and not Path(js).exists():
+        logger.error("The specified JavaScript file does not exist: %s", js)
+        sys.exit(-1)
+
+    if not config:
+        return
+
+    if not Path(config).exists():
+        logger.error("The specified configuration file does not exist: %s", config)
+        sys.exit(-1)
+
+    try:
+        with open(config, "r", encoding="utf-8") as f:
+            json.load(f)
+    except json.JSONDecodeError:
+        logger.error("The specified configuration file is not a valid JSON: %s", config)
+        sys.exit(-1)
+
+
+def prepare_decompile_dir(decompiled_path: Path):
+    """Make sure the decompile target is an empty directory we may write to
+
+    Args:
+        decompiled_path (Path): the decompile directory
+    """
+    if decompiled_path.exists():
+        if not is_reusable_decompile_dir(decompiled_path):
+            logger.error(
+                "The decompile target '%s' already exists and does not look like "
+                "an apktool output.\n"
+                "Remove or rename it, or use the --skip-decompile option "
+                "if it already contains the decompiled APK.",
+                decompiled_path,
+            )
+            sys.exit(-1)
+        shutil.rmtree(decompiled_path)
+
+    decompiled_path.mkdir(parents=True)
+
+
+def build_decompile_options(
+    decompiled_path: Path, force_manifest: bool, no_res: bool, decompile_opts: str
+):
+    """Assemble the apktool decode command line
+
+    Args:
+        decompiled_path (Path): where apktool should write the decompiled APK
+        force_manifest (bool): whether --force-manifest was given
+        no_res (bool): whether --no-res was given
+        decompile_opts (str): extra options given with --decompile-opts
+
+    Returns:
+        tuple: the option list, and no_res updated from --decompile-opts
+    """
+    options = ["d", "-o", str(decompiled_path.resolve()), "--force"]
+    if force_manifest:
+        options += ["--force-manifest"]
+    if no_res:
+        options += ["--no-res"]
+
+    if decompile_opts:
+        if "--no-res" in decompile_opts:
+            if no_res:
+                # remove no-res option if it's already in the list
+                options.remove("--no-res")
+            no_res = True
+        options += decompile_opts.split()
+
+    return options, no_res
+
+
+def normalize_arch(arch: str, skip_decompile: bool) -> str:
+    """Turn the --arch value into one of the names used internally
+
+    Args:
+        arch (str): value given with --arch, None to auto-detect over ADB
+        skip_decompile (bool): whether --skip-decompile was given
+
+    Returns:
+        str: 'multi-arch' or one of the supported architecture names
+    """
+    if arch is None:
+        return detect_adb_arch()
+
+    if arch.lower() == "multi-arch":
+        if skip_decompile:
+            logger.warning(
+                "The 'multi-arch' option requires decompiling the APK first to detect architectures"
+            )
+        return "multi-arch"
+
+    aliases = {"arm64-v8a": "arm64", "armeabi-v7a": "arm"}
+    return aliases.get(arch, arch)
+
+
+def wrap_js_file(js: str, js_delay: int) -> str:
+    """Write a delayed copy of the script and return its path
+
+    Args:
+        js (str): path given with --js
+        js_delay (int): seconds to wait before the script runs
+
+    Returns:
+        str: path of the wrapped copy
+    """
+    if js is None:
+        logger.error("The --js-delay option requires --js option to be specified.")
+        sys.exit(-1)
+
+    if js_delay < 0:
+        logger.error("Delay value must be a positive number.")
+        sys.exit(-1)
+
+    logger.info("JavaScript execution will be delayed by %d seconds", js_delay)
+
+    js_path = Path(js)
+    if not js_path.exists():
+        logger.error("The specified JavaScript file does not exist: %s", js)
+        sys.exit(-1)
+
+    try:
+        wrapped_content = wrap_js_with_timeout(
+            js_path.read_text(encoding="utf-8"), js_delay
+        )
+
+        # Keep the wrapped copy in a private temporary directory. Writing it
+        # next to the original silently overwrote any existing file of that
+        # name and failed outright when the directory was read-only.
+        temp_dir = tempfile.mkdtemp(prefix="frida-gadget-")
+        atexit.register(shutil.rmtree, temp_dir, True)
+        temp_js = Path(temp_dir).joinpath("wrapped.js")
+        temp_js.write_text(wrapped_content, encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        logger.error("Failed to process JavaScript file: %s", str(e))
+        sys.exit(-1)
+
+    logger.debug("Created wrapped JavaScript file: %s", temp_js)
+    return str(temp_js)
 
 
 def wrap_js_with_timeout(js_content: str, delay: int) -> str:
@@ -722,12 +1141,14 @@ def wrap_js_with_timeout(js_content: str, delay: int) -> str:
 }}, {delay * 1000});"""
 
 
-# pylint: disable=too-many-arguments
+# The signature is dictated by the click options below, one parameter per flag.
+# pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
 @click.command()
 @click.option(
     "--arch",
     default=None,
-    help="Specify the target architecture of the device. (options: arm64, x86_64, arm, x86, multi-arch)",
+    help="Specify the target architecture of the device. "
+    "(options: arm64, x86_64, arm, x86, multi-arch)",
 )
 @click.option("--config", help="Specify the Frida configuration file.")
 @click.option("--js", default=None, help="Specify the Frida gadget JavaScript file.")
@@ -755,7 +1176,8 @@ def wrap_js_with_timeout(js_content: str, delay: int) -> str:
 @click.option(
     "--github-repo",
     default=None,
-    help="Specify a custom GitHub repository for downloading Frida gadget (e.g., username/repo-name or full URL).",
+    help="Specify a custom GitHub repository for downloading Frida gadget "
+    "(e.g., username/repo-name or full URL).",
 )
 @click.option("--no-res", is_flag=True, help="Skip decoding resources.")
 @click.option(
@@ -785,10 +1207,22 @@ def wrap_js_with_timeout(js_content: str, delay: int) -> str:
     "--apktool-path", default=None, help="Specify the path or command to run apktool."
 )
 @click.option("--frida-version", default=None, help="Specify the Frida version to use.")
-@click.option("--ks", default=None, help="The keystore file. If not provided, will use debug keystore.")
+@click.option(
+    "--ks",
+    default=None,
+    help="The keystore file. If not provided, will use debug keystore.",
+)
 @click.option("--ks-alias", default=None, help="The alias of the used key in the keystore.")
-@click.option("--ks-key-pass", default=None, help="The password for the key. Prompted for if omitted.")
-@click.option("--ks-pass", default=None, help="The password for the keystore. Prompted for if omitted.")
+@click.option(
+    "--ks-key-pass",
+    default=None,
+    help="The password for the key. Prompted for if omitted.",
+)
+@click.option(
+    "--ks-pass",
+    default=None,
+    help="The password for the keystore. Prompted for if omitted.",
+)
 @click.option(
     "--version",
     is_flag=True,
@@ -798,7 +1232,7 @@ def wrap_js_with_timeout(js_content: str, delay: int) -> str:
     help="Show the version and exit.",
 )
 @click.argument("apk_path", type=click.Path(exists=True), required=True)
-def run(
+def run(  # NOSONAR: one parameter per CLI flag
     apk_path: str,
     arch: str,
     config: str,
@@ -827,18 +1261,7 @@ def run(
     apk_path = Path(apk_path)
 
     logger.info("APK: '%s'", apk_path)
-    if arch is None:
-        arch = detect_adb_arch()
-    elif arch.lower() == "multi-arch":
-        if skip_decompile:
-            logger.warning(
-                "The 'multi-arch' option requires decompiling the APK first to detect architectures"
-            )
-        arch = "multi-arch"
-    elif arch == "arm64-v8a":
-        arch = "arm64"
-    elif arch == "armeabi-v7a":
-        arch = "arm"
+    arch = normalize_arch(arch, skip_decompile)
 
     # A single library file only matches one ABI, so it cannot serve every
     # architecture found in the APK
@@ -849,140 +1272,26 @@ def run(
         )
         sys.exit(-1)
 
-    # Validate js-delay option
     if js_delay is not None:
-        if js is None:
-            logger.error("The --js-delay option requires --js option to be specified.")
-            sys.exit(-1)
-        if js_delay < 0:
-            logger.error("Delay value must be a positive number.")
-            sys.exit(-1)
-        logger.info("JavaScript execution will be delayed by %d seconds", js_delay)
+        js = wrap_js_file(js, js_delay)
 
-    # Process JavaScript file with delay if specified
-    if js and js_delay is not None:
-        js_path = Path(js)
-        if not js_path.exists():
-            logger.error("The specified JavaScript file does not exist: %s", js)
-            sys.exit(-1)
-
-        try:
-            original_content = js_path.read_text()
-            wrapped_content = wrap_js_with_timeout(original_content, js_delay)
-
-            # Keep the wrapped copy in a private temporary directory. Writing it
-            # next to the original silently overwrote any existing file of that
-            # name and failed outright when the directory was read-only.
-            temp_dir = tempfile.mkdtemp(prefix="frida-gadget-")
-            atexit.register(shutil.rmtree, temp_dir, True)
-            temp_js = Path(temp_dir).joinpath("wrapped.js")
-            temp_js.write_text(wrapped_content)
-            js = str(temp_js)
-            logger.debug("Created wrapped JavaScript file: %s", js)
-        except Exception as e:
-            logger.error("Failed to process JavaScript file: %s", str(e))
-            sys.exit(-1)
-
-    global APKTOOL
-    if apktool_path:
-        APKTOOL = apktool_path
-        apktool_parts = APKTOOL.split()
-        apktool_binary = apktool_parts[-1]
-        if not Path(apktool_binary).exists():
-            logger.error(
-                "The specified apktool path does not exist: %s", apktool_binary
-            )
-            sys.exit(-1)
-
-        if len(apktool_parts) > 1:
-            logger.info("Using custom apktool command: '%s'", APKTOOL)
-        else:
-            logger.info("Using custom apktool path: '%s'", APKTOOL)
-    else:
-        if not APKTOOL:
-            raise FileNotFoundError(
-                "apktool not found. Please install apktool and add it to your PATH environment.\n"
-                "For macOS: brew install apktool\n"
-                "For Windows: Download from https://ibotpeaches.github.io/Apktool/install/\n"
-                "For Linux: sudo apt-get install apktool\n"
-                "After installation, you may need to restart your terminal."
-            )
-
-    if arch != "multi-arch":
-        logger.info(
-            "Gadget Architecture(--arch): %s%s",
-            arch,
-            "(default)" if arch == "arm64" else "",
-        )
-    else:
-        logger.info(
-            "Gadget Architecture(--arch): %s (will inject for all architectures found in APK)",
-            arch,
-        )
-
-    if js and not Path(js).exists():
-        logger.error("The specified JavaScript file does not exist: %s", js)
-        sys.exit(-1)
-
-    if config and not Path(config).exists():
-        logger.error("The specified configuration file does not exist: %s", config)
-        sys.exit(-1)
-    elif config:
-        try:
-            with open(config, "r") as f:
-                json.load(f)
-        except json.JSONDecodeError:
-            logger.error(
-                "The specified configuration file is not a valid JSON: %s", config
-            )
-            sys.exit(-1)
-
-    if arch != "multi-arch":
-        arch = arch.lower()
-        supported_archs = ["arm", "arm64", "x86", "x86_64"]
-        if arch not in supported_archs:
-            logger.error(
-                "The --arch option only supports the following architectures: %s, multi-arch",
-                ", ".join(supported_archs),
-            )
-            sys.exit(-1)
+    apktool = resolve_apktool(apktool_path)
+    log_target_arch(arch)
+    validate_input_files(js, config)
+    arch = validate_arch(arch)
 
     # Make directory for decompile
     decompiled_path = get_decompiled_path(apk_path)
     if not skip_decompile:
         logger.debug('Decompiling the target APK using apktool\n"%s"', decompiled_path)
-        if decompiled_path.exists():
-            if not is_reusable_decompile_dir(decompiled_path):
-                logger.error(
-                    "The decompile target '%s' already exists and does not look like "
-                    "an apktool output.\n"
-                    "Remove or rename it, or use the --skip-decompile option "
-                    "if it already contains the decompiled APK.",
-                    decompiled_path,
-                )
-                sys.exit(-1)
-            shutil.rmtree(decompiled_path)
-        decompiled_path.mkdir(parents=True)
-
-        # APK decompile with apktool
-        decompile_option = ["d", "-o", str(decompiled_path.resolve()), "--force"]
-        if force_manifest:
-            decompile_option += ["--force-manifest"]
-        if no_res:
-            decompile_option += ["--no-res"]
-        if decompile_opts:
-            if "--no-res" in decompile_opts:
-                if no_res:
-                    # remove no-res option if it's already in the list
-                    decompile_option.remove("--no-res")
-                no_res = True
-            decompile_option += decompile_opts.split()
-
-        run_apktool(decompile_option, str(apk_path.resolve()))
-    else:
-        if not decompiled_path.exists():
-            logger.error("Decompiled directory not found: %s", decompiled_path)
-            sys.exit(-1)
+        prepare_decompile_dir(decompiled_path)
+        decompile_option, no_res = build_decompile_options(
+            decompiled_path, force_manifest, no_res, decompile_opts
+        )
+        run_apktool(decompile_option, str(apk_path.resolve()), apktool)
+    elif not decompiled_path.exists():
+        logger.error("Decompiled directory not found: %s", decompiled_path)
+        sys.exit(-1)
 
     # Process if decompile is success
     modified_dex_number = inject_gadget_into_apk(
@@ -994,10 +1303,7 @@ def run(
         main_activity,
         config,
         js,
-        custom_gadget_name,
-        custom_gadget_path,
-        frida_version,
-        github_repo,
+        GadgetSource(custom_gadget_name, custom_gadget_path, frida_version, github_repo),
     )
 
     # Rebuild with apktool, print apk_path if process is success
@@ -1010,66 +1316,19 @@ def run(
         if recompile_opts:
             recompile_option += recompile_opts.split()
 
-        run_apktool(recompile_option, str(decompiled_path.resolve()))
+        run_apktool(recompile_option, str(decompiled_path.resolve()), apktool)
         recompiled_apk_path = decompiled_path.joinpath("dist", apk_path.name)
         if not recompiled_apk_path.exists():
+            # Carrying on would repack and sign an APK that is not there
             logger.error("APK not found: %s", recompiled_apk_path)
-        else:
-            logger.info("Frida gadget injected into APK: %s", recompiled_apk_path)
+            sys.exit(-1)
+
+        logger.info("Frida gadget injected into APK: %s", recompiled_apk_path)
 
         # The wrapped JavaScript file is removed by the atexit hook that created it,
         # so it no longer leaks when --skip-recompile is used or the run fails.
 
-        # Copy original dex files except the modified one to the recompiled APK
-        logger.debug(
-            f"Copying original dex files (except modified one {modified_dex_number}) to the recompiled APK"
-        )
-        try:
-            # Create a temporary directory for extraction
-            with tempfile.TemporaryDirectory() as temp_dir:
-                temp_dir_path = Path(temp_dir)
-
-                # Extract original APK
-                original_apk_zip = zipfile.ZipFile(apk_path, 'r')
-                original_apk_zip.extractall(temp_dir_path)
-                original_apk_zip.close()
-
-                # Create a temporary file for the recompiled APK
-                with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-                    temp_file_path = Path(temp_file.name)
-
-                # Open recompiled APK for reading
-                recompiled_apk = zipfile.ZipFile(recompiled_apk_path, 'r')
-
-                # Create a new ZIP file
-                new_apk = zipfile.ZipFile(temp_file_path, 'w')
-
-                # Copy all files from recompiled APK except dex files
-                modified_dex_filename = (
-                    f"classes{modified_dex_number}.dex"
-                    if modified_dex_number and modified_dex_number > 1
-                    else "classes.dex"
-                )
-
-                for item in recompiled_apk.infolist():
-                    if item.filename == modified_dex_filename:
-                        logger.debug(f"Copying {item.filename} from recompiled APK")
-                        new_apk.writestr(item, recompiled_apk.read(item.filename))
-                    elif item.filename.startswith('classes') and item.filename.endswith('.dex'):
-                        dex_file = temp_dir_path.joinpath(item.filename)
-                        new_apk.write(str(dex_file), dex_file.name)
-                    else:
-                        new_apk.writestr(item, recompiled_apk.read(item.filename))
-
-                # Close all zip files
-                recompiled_apk.close()
-                new_apk.close()
-
-                # Replace the recompiled APK with the new one
-                shutil.move(temp_file_path, recompiled_apk_path)
-                logger.info("Successfully replaced dex files in the recompiled APK")
-        except Exception as e:
-            logger.error(f"Failed to copy original dex files: {str(e)}")
+        restore_original_dex(apk_path, recompiled_apk_path, modified_dex_number)
 
         if sign:
             logger.debug("Starting APK signing using uber-apk-signer")

--- a/scripts/frida_github.py
+++ b/scripts/frida_github.py
@@ -115,7 +115,8 @@ class FridaGithub:
         :param output_file:
         :return:
         """
-        assert output_file.endswith('.xz')
+        if not output_file.endswith('.xz'):
+            raise ValueError(f'The asset must be downloaded to a .xz path, got {output_file!r}.')
         filepath = Path(output_file)
         if filepath.exists() and filepath.stat().st_size > 0:
             return
@@ -132,7 +133,8 @@ class FridaGithub:
         :param gadget_path:
         :return:
         """
-        assert gadget_fullpath.endswith('.so')
+        if not gadget_fullpath.endswith('.so'):
+            raise ValueError(f'The gadget must be written to a .so path, got {gadget_fullpath!r}.')
         gadget_path = Path(gadget_fullpath)
         download_directory = gadget_path.parent
         if gadget_path.exists():

--- a/scripts/frida_github.py
+++ b/scripts/frida_github.py
@@ -1,4 +1,4 @@
-"""Github module for download frida gadget library"""
+"""Github module for download frida gadget library."""
 # Base code is sourced from the GitHub repository of Objection.
 # Source: https://github.com/sensepost/objection/blob/master/objection/utils/patchers/github.py
 import lzma
@@ -7,7 +7,7 @@ from pathlib import Path
 import requests
 
 class FridaGithub:
-    """ Interact with Github """
+    """Interact with Github."""
 
     DEFAULT_GITHUB_API_BASE = 'https://api.github.com/repos/frida/frida'
 
@@ -25,10 +25,7 @@ class FridaGithub:
     github_api_base = None
 
     def __init__(self, gadget_version: str = "", github_repo: str = ""):
-        """
-            Init a new instance of Github
-        """
-
+        """Init a new instance of Github."""
         if gadget_version:
             self.gadget_version = gadget_version
 
@@ -37,13 +34,11 @@ class FridaGithub:
 
     @classmethod
     def parse_repo(cls, github_repo: str) -> str:
-        """
-            Turn a repository reference into a Github API base URL.
+        """Turn a repository reference into a Github API base URL.
 
-            :param github_repo: 'owner/repo' or a github.com URL, empty for frida/frida
-            :return:
+        :param github_repo: 'owner/repo' or a github.com URL, empty for frida/frida
+        :return:
         """
-
         if not github_repo:
             return cls.DEFAULT_GITHUB_API_BASE
 
@@ -57,32 +52,26 @@ class FridaGithub:
 
     @property
     def latest_release_url(self) -> str:
-        """
-            Endpoint of the latest release of the selected repository.
+        """Endpoint of the latest release of the selected repository.
 
-            :return:
+        :return:
         """
-
         return f'{self.github_api_base}/releases/latest'
 
     @property
     def tagged_release_url(self) -> str:
-        """
-            Endpoint template of a tagged release of the selected repository.
+        """Endpoint template of a tagged release of the selected repository.
 
-            :return:
+        :return:
         """
-
         return f'{self.github_api_base}/releases/tags/{{tag}}'
 
     def _call(self, endpoint: str) -> dict:
-        """
-            Make a call to Github and cache the response.
+        """Make a call to Github and cache the response.
 
-            :param endpoint:
-            :return:
+        :param endpoint:
+        :return:
         """
-
         # return a cached response if possible
         if endpoint in self.request_cache:
             return self.request_cache[endpoint]
@@ -97,24 +86,19 @@ class FridaGithub:
         return results
 
     def get_latest_version(self) -> str:
-        """
-            Call Github and get the tag_name of the latest
-            release.
+        """Call Github and get the tag_name of the latest release.
 
-            :return:
+        :return:
         """
-
         self.gadget_version = self._call(self.latest_release_url)['tag_name']
 
         return self.gadget_version
 
     def get_assets(self) -> dict:
-        """
-            Gets the assets for the currently selected gadget_version.
+        """Get the assets for the currently selected gadget_version.
 
-            :return:
+        :return:
         """
-
         assets = self._call(self.tagged_release_url.format(tag=self.gadget_version))
 
         if 'assets' not in assets:
@@ -125,14 +109,12 @@ class FridaGithub:
         return assets['assets']
 
     def download_asset(self, url: str, output_file: str) -> None:
-        """
-            Download an asset from Github.
+        """Download an asset from Github.
 
-            :param url:
-            :param output_file:
-            :return:
+        :param url:
+        :param output_file:
+        :return:
         """
-
         assert output_file.endswith('.xz')
         filepath = Path(output_file)
         if filepath.exists() and filepath.stat().st_size > 0:
@@ -145,13 +127,11 @@ class FridaGithub:
                     asset.write(chunk)
 
     def download_gadget_so(self, url, gadget_fullpath: str) -> str:
-        """
-            Download the gadget library from Github.
+        """Download the gadget library from Github.
 
-            :param gadget_path:
-            :return:
+        :param gadget_path:
+        :return:
         """
-
         assert gadget_fullpath.endswith('.so')
         gadget_path = Path(gadget_fullpath)
         download_directory = gadget_path.parent

--- a/scripts/frida_github.py
+++ b/scripts/frida_github.py
@@ -56,11 +56,23 @@ class FridaGithub:
         return f'https://api.github.com/repos/{match.group("owner")}/{match.group("repo")}'
 
     @property
-    def GITHUB_LATEST_RELEASE(self):
+    def latest_release_url(self) -> str:
+        """
+            Endpoint of the latest release of the selected repository.
+
+            :return:
+        """
+
         return f'{self.github_api_base}/releases/latest'
 
     @property
-    def GITHUB_TAGGED_RELEASE(self):
+    def tagged_release_url(self) -> str:
+        """
+            Endpoint template of a tagged release of the selected repository.
+
+            :return:
+        """
+
         return f'{self.github_api_base}/releases/tags/{{tag}}'
 
     def _call(self, endpoint: str) -> dict:
@@ -92,7 +104,7 @@ class FridaGithub:
             :return:
         """
 
-        self.gadget_version = self._call(self.GITHUB_LATEST_RELEASE)['tag_name']
+        self.gadget_version = self._call(self.latest_release_url)['tag_name']
 
         return self.gadget_version
 
@@ -103,7 +115,7 @@ class FridaGithub:
             :return:
         """
 
-        assets = self._call(self.GITHUB_TAGGED_RELEASE.format(tag=self.gadget_version))
+        assets = self._call(self.tagged_release_url.format(tag=self.gadget_version))
 
         if 'assets' not in assets:
             raise FileNotFoundError(

--- a/scripts/logger.py
+++ b/scripts/logger.py
@@ -1,4 +1,4 @@
-"""logger.py"""
+"""logger.py."""
 import logging
 from colorlog import ColoredFormatter
 

--- a/scripts/uber_apk_signer_github.py
+++ b/scripts/uber_apk_signer_github.py
@@ -9,7 +9,9 @@ import requests
 class UberApkSignerGithub:
     """ Interact with Github """
 
-    GITHUB_LATEST_RELEASE = 'https://api.github.com/repos/patrickfav/uber-apk-signer/releases/latest'
+    GITHUB_LATEST_RELEASE = (
+        'https://api.github.com/repos/patrickfav/uber-apk-signer/releases/latest'
+    )
 
     # the 'context' of this Github instance
     signer_version = None
@@ -70,7 +72,7 @@ class UberApkSignerGithub:
             :param url:
             :param output_file:
             :return:
-        """        
+        """
         filepath = Path(output_file)
         if filepath.exists() and filepath.stat().st_size > 0:
             return
@@ -98,29 +100,30 @@ class UberApkSignerGithub:
             checksum_download_url, uber_apk_signer_download_url = \
                 uber_apk_signer_download_url, checksum_download_url
         assert uber_apk_signer_download_url.endswith('.jar'), 'Download URL must end with .jar'
-    
+
         signer_path = Path(signer_fullpath)
         download_directory = signer_path.parent
         if signer_path.exists():
             return signer_fullpath
 
         if not download_directory.exists():
-            download_directory.mkdir(parents=True, exist_ok=True)        
+            download_directory.mkdir(parents=True, exist_ok=True)
 
         check_sum_fullpath = signer_fullpath[:-4] + '.sha256'
         self.download_asset(checksum_download_url, check_sum_fullpath)
 
         with open(check_sum_fullpath, 'rb') as checksum_file:
             checksum = checksum_file.read(64).decode('utf-8')
-        
+
         self.download_asset(uber_apk_signer_download_url, signer_fullpath)
         with open(signer_fullpath, 'rb') as signer_file:
             signer_data = signer_file.read()
             signer_hash = hashlib.sha256(signer_data).hexdigest()
-        
+
         if checksum != signer_hash:
             os.remove(signer_fullpath)
             os.remove(check_sum_fullpath)
-            raise ValueError('The downloaded uber-apk-signer-*.jar file does not match the checksum.')
+            raise ValueError(
+                'The downloaded uber-apk-signer-*.jar file does not match the checksum.')
 
         return signer_fullpath

--- a/scripts/uber_apk_signer_github.py
+++ b/scripts/uber_apk_signer_github.py
@@ -1,4 +1,4 @@
-"""Github module for download frida gadget library"""
+"""Github module for download frida gadget library."""
 # Base code is sourced from the GitHub repository of Objection.
 # Source: https://github.com/sensepost/objection/blob/master/objection/utils/patchers/github.py
 from pathlib import Path
@@ -7,7 +7,7 @@ import os
 import requests
 
 class UberApkSignerGithub:
-    """ Interact with Github """
+    """Interact with Github."""
 
     GITHUB_LATEST_RELEASE = (
         'https://api.github.com/repos/patrickfav/uber-apk-signer/releases/latest'
@@ -17,23 +17,18 @@ class UberApkSignerGithub:
     signer_version = None
 
     def __init__(self, signer_version: str = None):
-        """
-            Init a new instance of Github
-        """
-
+        """Init a new instance of Github."""
         if signer_version:
             self.signer_version = signer_version
 
         self.request_cache = {}
 
     def _call(self, endpoint: str) -> dict:
-        """
-            Make a call to Github and cache the response.
+        """Make a call to Github and cache the response.
 
-            :param endpoint:
-            :return:
+        :param endpoint:
+        :return:
         """
-
         # return a cached response if possible
         if endpoint in self.request_cache:
             return self.request_cache[endpoint]
@@ -48,12 +43,10 @@ class UberApkSignerGithub:
         return results
 
     def get_assets(self) -> dict:
-        """
-            Gets the assets for the currently selected signer_version.
+        """Get the assets for the currently selected signer_version.
 
-            :return:
+        :return:
         """
-
         assets = self._call(self.GITHUB_LATEST_RELEASE)
 
         self.signer_version = assets['tag_name'][1:]
@@ -66,12 +59,11 @@ class UberApkSignerGithub:
         return assets['assets']
 
     def download_asset(self, url: str, output_file: str) -> None:
-        """
-            Download an asset from Github.
+        """Download an asset from Github.
 
-            :param url:
-            :param output_file:
-            :return:
+        :param url:
+        :param output_file:
+        :return:
         """
         filepath = Path(output_file)
         if filepath.exists() and filepath.stat().st_size > 0:
@@ -84,12 +76,11 @@ class UberApkSignerGithub:
                     asset.write(chunk)
 
     def download_signer_jar(self, assets: list, signer_fullpath: str) -> str:
-        """
-            Download the signer jar library from Github.
+        """Download the signer jar library from Github.
 
-            :param assets:
-            :param signer_path:
-            :return:
+        :param assets:
+        :param signer_path:
+        :return:
         """
         assert len(assets) == 2, 'Unable to determine the correct asset to download.'
         assert signer_fullpath.endswith('.jar'), 'Signer path must end with .jar'

--- a/scripts/uber_apk_signer_github.py
+++ b/scripts/uber_apk_signer_github.py
@@ -82,15 +82,18 @@ class UberApkSignerGithub:
         :param signer_path:
         :return:
         """
-        assert len(assets) == 2, 'Unable to determine the correct asset to download.'
-        assert signer_fullpath.endswith('.jar'), 'Signer path must end with .jar'
+        if len(assets) != 2:
+            raise ValueError('Unable to determine the correct asset to download.')
+        if not signer_fullpath.endswith('.jar'):
+            raise ValueError('Signer path must end with .jar')
 
         checksum_download_url = assets[0]['browser_download_url']
         uber_apk_signer_download_url = assets[1]['browser_download_url']
         if assets[1]['name'] == 'checksum-sha256.txt':
             checksum_download_url, uber_apk_signer_download_url = \
                 uber_apk_signer_download_url, checksum_download_url
-        assert uber_apk_signer_download_url.endswith('.jar'), 'Download URL must end with .jar'
+        if not uber_apk_signer_download_url.endswith('.jar'):
+            raise ValueError('Download URL must end with .jar')
 
         signer_path = Path(signer_fullpath)
         download_directory = signer_path.parent

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+# Docstrings across this project follow the Google style: a summary line,
+# then 'Args:' / 'Returns:' / 'Raises:' sections without dashed underlines.
+# Declaring it here keeps local runs and CI from applying the numpy rules,
+# which would ask for underlines the codebase has never used.
+[pydocstyle]
+convention = google
+match = .*\.py

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for frida-gadget."""

--- a/tests/test_apk_utils.py
+++ b/tests/test_apk_utils.py
@@ -1,4 +1,4 @@
-"""Tests for scripts.apk_utils"""
+"""Tests for scripts.apk_utils."""
 import xml.etree.ElementTree as ET
 from types import SimpleNamespace
 
@@ -15,7 +15,7 @@ LAUNCHER_FILTER = (
 
 
 def fake_apk(*bodies):
-    """Build an object exposing the manifests the way androguard's APK does"""
+    """Build an object exposing the manifests the way androguard's APK does."""
     manifests = {}
     for idx, body in enumerate(bodies):
         xml = (
@@ -27,19 +27,19 @@ def fake_apk(*bodies):
 
 
 def test_android_namespace_matches_androguard():
-    """The hardcoded namespace has to agree with the one androguard resolves"""
+    """The hardcoded namespace has to agree with the one androguard resolves."""
     # pylint: disable=protected-access
     assert ANDROID_NS + "name" == APK._ns("name")
 
 
 def test_single_main_activity():
-    """An activity with both MAIN and LAUNCHER is the entrypoint"""
+    """An activity with both MAIN and LAUNCHER is the entrypoint."""
     apk = fake_apk(f'<activity android:name="com.e.Main">{LAUNCHER_FILTER}</activity>')
     assert get_main_activity(apk) == "com.e.Main"
 
 
 def test_activity_alias_resolves_to_target():
-    """An alias points at the class that actually has to be patched"""
+    """An alias points at the class that actually has to be patched."""
     apk = fake_apk(
         '<activity android:name="com.e.Real"/>'
         '<activity-alias android:name="com.e.Alias" '
@@ -49,7 +49,7 @@ def test_activity_alias_resolves_to_target():
 
 
 def test_disabled_activity_is_skipped():
-    """android:enabled="false" rules an activity out"""
+    """android:enabled="false" rules an activity out."""
     apk = fake_apk(
         '<activity android:name="com.e.Off" android:enabled="false">'
         f"{LAUNCHER_FILTER}</activity>"
@@ -59,7 +59,7 @@ def test_disabled_activity_is_skipped():
 
 
 def test_multiple_main_activities_report_minus_one():
-    """The caller has to ask the user which one to patch"""
+    """The caller has to ask the user which one to patch."""
     apk = fake_apk(
         f'<activity android:name="com.e.A">{LAUNCHER_FILTER}</activity>'
         f'<activity android:name="com.e.B">{LAUNCHER_FILTER}</activity>'
@@ -68,7 +68,7 @@ def test_multiple_main_activities_report_minus_one():
 
 
 def test_activities_are_collected_across_manifests():
-    """Split manifests are searched too"""
+    """Split manifests are searched too."""
     apk = fake_apk(
         f'<activity android:name="com.e.One">{LAUNCHER_FILTER}</activity>',
         f'<activity android:name="com.e.Two">{LAUNCHER_FILTER}</activity>',
@@ -77,12 +77,12 @@ def test_activities_are_collected_across_manifests():
 
 
 def test_no_main_activity():
-    """A plain activity is not an entrypoint"""
+    """A plain activity is not an entrypoint."""
     assert get_main_activity(fake_apk('<activity android:name="com.e.Plain"/>')) is None
 
 
 def test_main_without_launcher_category():
-    """MAIN alone does not make an activity the launcher entry"""
+    """MAIN alone does not make an activity the launcher entry."""
     apk = fake_apk(
         '<activity android:name="com.e.M"><intent-filter>'
         '<action android:name="android.intent.action.MAIN"/>'
@@ -92,7 +92,7 @@ def test_main_without_launcher_category():
 
 
 def test_launcher_without_main_action():
-    """LAUNCHER alone does not make an activity the launcher entry"""
+    """LAUNCHER alone does not make an activity the launcher entry."""
     apk = fake_apk(
         '<activity android:name="com.e.L"><intent-filter>'
         '<category android:name="android.intent.category.LAUNCHER"/>'
@@ -102,17 +102,17 @@ def test_launcher_without_main_action():
 
 
 def test_activity_without_name_is_ignored():
-    """An entry we cannot name cannot be patched"""
+    """An entry we cannot name cannot be patched."""
     assert get_main_activity(fake_apk(f"<activity>{LAUNCHER_FILTER}</activity>")) is None
 
 
 def test_empty_manifest():
-    """A manifest without activities yields nothing"""
+    """A manifest without activities yields nothing."""
     assert get_main_activity(fake_apk("")) is None
 
 
 def test_none_manifest_entries_are_skipped():
-    """androguard stores None for manifests it could not parse"""
+    """androguard stores None for manifests it could not parse."""
     apk = fake_apk(f'<activity android:name="com.e.Main">{LAUNCHER_FILTER}</activity>')
     apk.xml["broken.xml"] = None
     assert get_main_activity(apk) == "com.e.Main"

--- a/tests/test_apk_utils.py
+++ b/tests/test_apk_utils.py
@@ -1,0 +1,118 @@
+"""Tests for scripts.apk_utils"""
+import xml.etree.ElementTree as ET
+from types import SimpleNamespace
+
+from androguard.core.apk import APK
+
+from scripts.apk_utils import ANDROID_NS, get_main_activity
+
+LAUNCHER_FILTER = (
+    "<intent-filter>"
+    '<action android:name="android.intent.action.MAIN"/>'
+    '<category android:name="android.intent.category.LAUNCHER"/>'
+    "</intent-filter>"
+)
+
+
+def fake_apk(*bodies):
+    """Build an object exposing the manifests the way androguard's APK does"""
+    manifests = {}
+    for idx, body in enumerate(bodies):
+        xml = (
+            '<manifest xmlns:android="http://schemas.android.com/apk/res/android">'
+            f"<application>{body}</application></manifest>"
+        )
+        manifests[f"manifest{idx}.xml"] = ET.fromstring(xml)
+    return SimpleNamespace(xml=manifests)
+
+
+def test_android_namespace_matches_androguard():
+    """The hardcoded namespace has to agree with the one androguard resolves"""
+    # pylint: disable=protected-access
+    assert ANDROID_NS + "name" == APK._ns("name")
+
+
+def test_single_main_activity():
+    """An activity with both MAIN and LAUNCHER is the entrypoint"""
+    apk = fake_apk(f'<activity android:name="com.e.Main">{LAUNCHER_FILTER}</activity>')
+    assert get_main_activity(apk) == "com.e.Main"
+
+
+def test_activity_alias_resolves_to_target():
+    """An alias points at the class that actually has to be patched"""
+    apk = fake_apk(
+        '<activity android:name="com.e.Real"/>'
+        '<activity-alias android:name="com.e.Alias" '
+        f'android:targetActivity="com.e.Real">{LAUNCHER_FILTER}</activity-alias>'
+    )
+    assert get_main_activity(apk) == "com.e.Real"
+
+
+def test_disabled_activity_is_skipped():
+    """android:enabled="false" rules an activity out"""
+    apk = fake_apk(
+        '<activity android:name="com.e.Off" android:enabled="false">'
+        f"{LAUNCHER_FILTER}</activity>"
+        f'<activity android:name="com.e.On">{LAUNCHER_FILTER}</activity>'
+    )
+    assert get_main_activity(apk) == "com.e.On"
+
+
+def test_multiple_main_activities_report_minus_one():
+    """The caller has to ask the user which one to patch"""
+    apk = fake_apk(
+        f'<activity android:name="com.e.A">{LAUNCHER_FILTER}</activity>'
+        f'<activity android:name="com.e.B">{LAUNCHER_FILTER}</activity>'
+    )
+    assert get_main_activity(apk) == -1
+
+
+def test_activities_are_collected_across_manifests():
+    """Split manifests are searched too"""
+    apk = fake_apk(
+        f'<activity android:name="com.e.One">{LAUNCHER_FILTER}</activity>',
+        f'<activity android:name="com.e.Two">{LAUNCHER_FILTER}</activity>',
+    )
+    assert get_main_activity(apk) == -1
+
+
+def test_no_main_activity():
+    """A plain activity is not an entrypoint"""
+    assert get_main_activity(fake_apk('<activity android:name="com.e.Plain"/>')) is None
+
+
+def test_main_without_launcher_category():
+    """MAIN alone does not make an activity the launcher entry"""
+    apk = fake_apk(
+        '<activity android:name="com.e.M"><intent-filter>'
+        '<action android:name="android.intent.action.MAIN"/>'
+        "</intent-filter></activity>"
+    )
+    assert get_main_activity(apk) is None
+
+
+def test_launcher_without_main_action():
+    """LAUNCHER alone does not make an activity the launcher entry"""
+    apk = fake_apk(
+        '<activity android:name="com.e.L"><intent-filter>'
+        '<category android:name="android.intent.category.LAUNCHER"/>'
+        "</intent-filter></activity>"
+    )
+    assert get_main_activity(apk) is None
+
+
+def test_activity_without_name_is_ignored():
+    """An entry we cannot name cannot be patched"""
+    assert get_main_activity(fake_apk(f"<activity>{LAUNCHER_FILTER}</activity>")) is None
+
+
+def test_empty_manifest():
+    """A manifest without activities yields nothing"""
+    assert get_main_activity(fake_apk("")) is None
+
+
+def test_none_manifest_entries_are_skipped():
+    """androguard stores None for manifests it could not parse"""
+    apk = fake_apk(f'<activity android:name="com.e.Main">{LAUNCHER_FILTER}</activity>')
+    apk.xml["broken.xml"] = None
+    assert get_main_activity(apk) == "com.e.Main"

--- a/tests/test_apk_utils.py
+++ b/tests/test_apk_utils.py
@@ -112,7 +112,7 @@ def test_empty_manifest():
 
 
 def test_none_manifest_entries_are_skipped():
-    """androguard stores None for manifests it could not parse."""
+    """Manifests androguard could not parse are stored as None."""
     apk = fake_apk(f'<activity android:name="com.e.Main">{LAUNCHER_FILTER}</activity>')
     apk.xml["broken.xml"] = None
     assert get_main_activity(apk) == "com.e.Main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,7 +79,8 @@ def test_decompile_options_carry_the_flags(tmp_path):
     options, no_res = cli.build_decompile_options(tmp_path, True, True, None)
 
     assert options[:2] == ["d", "-o"]
-    assert "--force" in options and "--force-manifest" in options
+    assert "--force" in options
+    assert "--force-manifest" in options
     assert "--no-res" in options
     assert no_res is True
 
@@ -344,7 +345,8 @@ def test_passwords_are_redacted():
 
     redacted = cli.redact_passwords(cmd)
 
-    assert "hunter2" not in redacted and "s3cr3t" not in redacted
+    assert "hunter2" not in redacted
+    assert "s3cr3t" not in redacted
     assert redacted.count("***") == 2
     assert cmd[-1] == "s3cr3t", "the original command must not be modified"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,15 +1,484 @@
-"""test_cli.py"""
-from pathlib import Path
-from scripts.cli import run
-from click.testing import CliRunner
+"""Tests for scripts.cli"""
+import io
+import json
+import subprocess
 
-p = Path(__file__)
-ROOT_DIR = p.parent.resolve()
+import pytest
 
-def test_run():
-    """test frida-gadget run
-    """
-    runner = CliRunner()
-    demo_apk_path = str(ROOT_DIR.joinpath('demo-apk/handtrackinggpu.apk').resolve())
-    result = runner.invoke(run, [demo_apk_path])
-    assert result.exit_code == 0
+from scripts import cli
+
+
+class FakeStdin:  # pylint: disable=too-few-public-methods
+    """Stand-in for sys.stdin with a controllable isatty()"""
+
+    def __init__(self, tty):
+        self.tty = tty
+
+    def isatty(self):
+        """Report whether this stream is a terminal"""
+        return self.tty
+
+
+# --- decompile directory -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("documents.apk", "documents"),
+        ("my.app.v1.2.apk", "my.app.v1.2"),
+        # Without an extension there is nothing to strip, and truncating the
+        # name used to point at the directory holding the APK
+        ("app", "app_decompiled"),
+        ("base", "base_decompiled"),
+        (".apk", ".apk_decompiled"),
+    ],
+)
+def test_decompile_target_stays_next_to_the_apk(tmp_path, name, expected):
+    """The decompile directory is a sibling of the APK, never its parent"""
+    apk = tmp_path / name
+    apk.write_bytes(b"PK\x03\x04")
+
+    decompiled = cli.get_decompiled_path(apk)
+
+    assert decompiled.name == expected
+    assert decompiled.parent == tmp_path.resolve()
+    assert decompiled != tmp_path.resolve()
+
+
+def test_empty_directory_is_reusable(tmp_path):
+    """Nothing can be lost by removing an empty directory"""
+    assert cli.is_reusable_decompile_dir(tmp_path) is True
+
+
+@pytest.mark.parametrize("marker", ["apktool.yml", "AndroidManifest.xml", "smali"])
+def test_apktool_output_is_reusable(tmp_path, marker):
+    """A previous decompile, complete or interrupted, may be replaced"""
+    (tmp_path / marker).write_text("x", encoding="utf-8")
+    assert cli.is_reusable_decompile_dir(tmp_path) is True
+
+
+def test_unrelated_directory_is_not_reusable(tmp_path):
+    """A directory that merely shares the APK name must survive"""
+    (tmp_path / "holiday.jpg").write_text("x", encoding="utf-8")
+    assert cli.is_reusable_decompile_dir(tmp_path) is False
+
+
+def test_regular_file_is_not_reusable(tmp_path):
+    """rmtree cannot be pointed at a file"""
+    target = tmp_path / "plain"
+    target.write_text("x", encoding="utf-8")
+    assert cli.is_reusable_decompile_dir(target) is False
+
+
+# --- apktool -------------------------------------------------------------
+
+
+def test_decompile_options_carry_the_flags(tmp_path):
+    """The apktool command line reflects the CLI flags"""
+    options, no_res = cli.build_decompile_options(tmp_path, True, True, None)
+
+    assert options[:2] == ["d", "-o"]
+    assert "--force" in options and "--force-manifest" in options
+    assert "--no-res" in options
+    assert no_res is True
+
+
+def test_no_res_is_not_passed_twice(tmp_path):
+    """--no-res given both ways still reaches apktool once"""
+    options, no_res = cli.build_decompile_options(tmp_path, False, True, "--no-res")
+
+    assert options.count("--no-res") == 1
+    assert no_res is True
+
+
+def test_no_res_in_decompile_opts_updates_the_flag(tmp_path):
+    """--decompile-opts can turn on no_res for the injection step"""
+    options, no_res = cli.build_decompile_options(tmp_path, False, False, "--no-res")
+
+    assert options.count("--no-res") == 1
+    assert no_res is True
+
+
+def test_apktool_falls_back_to_the_one_on_path(monkeypatch):
+    """Without --apktool-path the command found on PATH is used"""
+    monkeypatch.setattr(cli, "APKTOOL", "/usr/local/bin/apktool")
+    assert cli.resolve_apktool(None) == "/usr/local/bin/apktool"
+
+
+def test_missing_apktool_is_reported(monkeypatch):
+    """Without apktool anywhere the run cannot start"""
+    monkeypatch.setattr(cli, "APKTOOL", None)
+    with pytest.raises(FileNotFoundError):
+        cli.resolve_apktool(None)
+
+
+def test_apktool_path_must_exist():
+    """A missing --apktool-path is reported instead of failing later"""
+    with pytest.raises(SystemExit):
+        cli.resolve_apktool("/nonexistent/apktool")
+
+
+# --- architecture --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "given, expected",
+    [
+        ("arm64-v8a", "arm64"),
+        ("armeabi-v7a", "arm"),
+        ("multi-arch", "multi-arch"),
+        ("MULTI-ARCH", "multi-arch"),
+        ("x86_64", "x86_64"),
+    ],
+)
+def test_arch_aliases(given, expected):
+    """Device ABI names are accepted alongside the short names"""
+    assert cli.normalize_arch(given, False) == expected
+
+
+def test_unsupported_arch_is_rejected():
+    """An architecture we cannot download a gadget for stops the run"""
+    with pytest.raises(SystemExit):
+        cli.validate_arch("mips")
+
+
+def test_multi_arch_skips_validation():
+    """'multi-arch' is resolved from the APK later on"""
+    assert cli.validate_arch("multi-arch") == "multi-arch"
+
+
+# --- gadget naming -------------------------------------------------------
+
+
+def test_custom_gadget_name_wins():
+    """--custom-gadget-name decides the library name"""
+    assert cli.resolve_gadget_name("/x/frida.so", "mygadget", "arm64") == "mygadget.so"
+
+
+def test_custom_gadget_name_applies_to_multi_arch():
+    """One name resolves in every lib/<abi>, so it works for multi-arch too"""
+    assert cli.resolve_gadget_name("/x/frida.so", "mygadget", "multi-arch") == "mygadget.so"
+
+
+def test_multi_arch_uses_an_architecture_free_name():
+    """The downloaded name carries the ABI, which loadLibrary cannot use"""
+    name = cli.resolve_gadget_name("/x/frida-gadget-17-android-arm64.so", None, "multi-arch")
+    assert name == "libfrida-gadget.so"
+
+
+def test_downloaded_gadget_keeps_its_name():
+    """Without overrides the downloaded file name is used as-is"""
+    assert cli.resolve_gadget_name("/x/frida-gadget.so", None, "arm64") == "frida-gadget.so"
+
+
+def test_unknown_architecture_has_no_abi_directory(tmp_path):
+    """An ABI directory we do not know about is refused"""
+    with pytest.raises(NotImplementedError):
+        cli.prepare_lib_dir(tmp_path, "mips")
+
+
+def test_lib_directory_is_created(tmp_path):
+    """lib/<abi> is created even when the APK ships no native libraries"""
+    lib_dir = cli.prepare_lib_dir(tmp_path, "arm64")
+    assert lib_dir == tmp_path / "lib" / "arm64-v8a"
+    assert lib_dir.is_dir()
+
+
+# --- gadget config -------------------------------------------------------
+
+
+def test_config_is_generated_for_a_script(tmp_path):
+    """--js alone produces a config pointing at the uploaded script"""
+    upload_files = {"config": None, "script": "s.js"}
+    cli.write_gadget_config(None, "s.js", tmp_path, "libfoo", upload_files)
+
+    written = json.loads((tmp_path / "libfoo.config.so").read_text(encoding="utf-8"))
+    assert written == {"interaction": {"type": "script", "path": "libfoo.script.so"}}
+    assert "config" not in upload_files
+
+
+def test_supplied_config_gets_the_script_path_rewritten(tmp_path):
+    """The path in the user's config is replaced by the uploaded name"""
+    config = tmp_path / "gadget.json"
+    config.write_text(
+        json.dumps({"interaction": {"type": "script", "path": "/data/local/tmp/a.js"}}),
+        encoding="utf-8",
+    )
+    upload_files = {"config": str(config), "script": "s.js"}
+
+    cli.write_gadget_config(str(config), "s.js", tmp_path, "libfoo", upload_files)
+
+    written = json.loads((tmp_path / "libfoo.config.so").read_text(encoding="utf-8"))
+    assert written["interaction"]["path"] == "libfoo.script.so"
+    assert "config" not in upload_files
+
+
+def test_config_without_script_is_uploaded_untouched(tmp_path):
+    """Without --js the config is left for the upload step to copy"""
+    config = tmp_path / "gadget.json"
+    config.write_text(
+        json.dumps({"interaction": {"type": "listen", "address": "127.0.0.1"}}),
+        encoding="utf-8",
+    )
+    upload_files = {"config": str(config), "script": None}
+
+    cli.write_gadget_config(str(config), None, tmp_path, "libfoo", upload_files)
+
+    assert not (tmp_path / "libfoo.config.so").exists()
+    assert upload_files["config"] == str(config)
+
+
+def test_config_must_declare_an_interaction(tmp_path):
+    """A config frida cannot act on stops the run"""
+    config = tmp_path / "gadget.json"
+    config.write_text(json.dumps({}), encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        cli.load_config_data(str(config))
+
+
+def test_script_config_must_declare_a_path(tmp_path):
+    """'type: script' without a path would leave the gadget idle"""
+    config = tmp_path / "gadget.json"
+    config.write_text(json.dumps({"interaction": {"type": "script"}}), encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        cli.warn_config_without_script(str(config))
+
+
+# --- smali patching ------------------------------------------------------
+
+
+ONCREATE_SMALI = [
+    ".class public Lcom/e/Main;",
+    ".method protected onCreate(Landroid/os/Bundle;)V",
+    "    .locals 2",
+    "    return-void",
+    ".end method",
+]
+
+
+def test_load_library_call_is_inserted_into_oncreate():
+    """The call lands right after the .locals declaration"""
+    text = list(ONCREATE_SMALI)
+
+    assert cli.insert_load_library_call(text, "libfrida-gadget") is True
+    assert text[3] == '    const-string v0, "frida-gadget"'
+    assert "System;->loadLibrary" in text[4]
+
+
+def test_locals_zero_is_raised_to_one():
+    """A method with no registers gets one for the library name"""
+    text = [
+        ".method protected onCreate(Landroid/os/Bundle;)V",
+        "    .locals 0",
+        "    return-void",
+    ]
+
+    assert cli.insert_load_library_call(text, "libfoo") is True
+    assert text[1].strip() == ".locals 1"
+
+
+def test_method_without_locals_is_skipped():
+    """Without a .locals declaration there is no register to use"""
+    text = [
+        ".method protected onCreate(Landroid/os/Bundle;)V",
+        "    return-void",
+        ".end method",
+        ".method public constructor <init>()V",
+        "    .locals 1",
+        "    return-void",
+    ]
+
+    assert cli.insert_load_library_call(text, "libfoo") is True
+    assert 'const-string v0, "foo"' in text[5]
+
+
+def test_no_entrypoint_reports_failure():
+    """A class without onCreate or <init> cannot be patched"""
+    assert cli.insert_load_library_call([".class public Lcom/e/Main;"], "libfoo") is False
+
+
+def test_trailing_method_declaration_does_not_crash():
+    """A truncated smali file must not raise IndexError"""
+    assert cli.insert_load_library_call(
+        [".method protected onCreate(Landroid/os/Bundle;)V"], "libfoo"
+    ) is False
+
+
+def test_activity_smali_is_found_in_a_split_dex(tmp_path):
+    """Classes live in smali_classes<N> once the APK is multidex"""
+    target = tmp_path / "smali_classes3" / "com" / "e" / "Main.smali"
+    target.parent.mkdir(parents=True)
+    target.write_text(".class public Lcom/e/Main;", encoding="utf-8")
+
+    found, number = cli.find_activity_smali(tmp_path, "com.e.Main")
+
+    assert found == target
+    assert number == 3
+
+
+def test_activity_smali_in_the_primary_dex_has_no_number(tmp_path):
+    """The plain 'smali' directory maps to classes.dex"""
+    target = tmp_path / "smali" / "com" / "e" / "Main.smali"
+    target.parent.mkdir(parents=True)
+    target.write_text(".class public Lcom/e/Main;", encoding="utf-8")
+
+    assert cli.find_activity_smali(tmp_path, "com.e.Main") == (target, None)
+
+
+def test_missing_activity_smali_is_reported(tmp_path):
+    """A class apktool never produced stops the run"""
+    (tmp_path / "smali").mkdir()
+    with pytest.raises(FileNotFoundError):
+        cli.find_activity_smali(tmp_path, "com.e.Missing")
+
+
+# --- signing -------------------------------------------------------------
+
+
+def test_passwords_are_redacted():
+    """A failing signer must not print the keystore passwords"""
+    cmd = ["java", "--ks", "/k.jks", "--ksKeyPass", "hunter2", "--ksPass", "s3cr3t"]
+
+    redacted = cli.redact_passwords(cmd)
+
+    assert "hunter2" not in redacted and "s3cr3t" not in redacted
+    assert redacted.count("***") == 2
+    assert cmd[-1] == "s3cr3t", "the original command must not be modified"
+
+
+def test_redaction_survives_a_trailing_flag():
+    """A flag without its value must not walk off the end of the list"""
+    assert cli.redact_passwords(["java", "--ksPass"]) == ["java", "--ksPass"]
+
+
+def test_stdin_without_a_terminal(monkeypatch):
+    """A pipe cannot answer a password prompt"""
+    monkeypatch.setattr("sys.stdin", io.StringIO())
+    assert cli.stdin_is_interactive() is False
+
+
+def test_stdin_that_was_closed(monkeypatch):
+    """A closed stream raises rather than answering isatty()"""
+
+    class Closed:  # pylint: disable=too-few-public-methods
+        """Raises the way a closed file object does"""
+
+        def isatty(self):
+            """Fail the way a closed stream does"""
+            raise ValueError("I/O operation on closed file")
+
+    monkeypatch.setattr("sys.stdin", Closed())
+    assert cli.stdin_is_interactive() is False
+
+
+def test_missing_stdin(monkeypatch):
+    """Windowed interpreters can leave sys.stdin unset"""
+    monkeypatch.setattr("sys.stdin", None)
+    assert cli.stdin_is_interactive() is False
+
+
+def test_signer_keeps_the_pipe_without_a_terminal(monkeypatch):
+    """Handing over a stdin nobody can type into would hang the run"""
+    captured = {}
+    monkeypatch.setattr(cli, "download_signer", lambda: "/signer.jar")
+    monkeypatch.setattr("sys.stdin", FakeStdin(tty=False))
+    monkeypatch.setattr(cli.subprocess, "Popen", _popen_recorder(captured))
+
+    cli.sign_apk("/out/app.apk", ks="/k.jks")
+
+    assert captured["stdout"] is subprocess.PIPE
+    assert captured["input"] == b"\n"
+
+
+def test_signer_gets_the_terminal_when_there_is_one(monkeypatch):
+    """uber-apk-signer prompts for the passwords it was not given"""
+    captured = {}
+    monkeypatch.setattr(cli, "download_signer", lambda: "/signer.jar")
+    monkeypatch.setattr("sys.stdin", FakeStdin(tty=True))
+    monkeypatch.setattr(cli.subprocess, "Popen", _popen_recorder(captured))
+
+    cli.sign_apk("/out/app.apk", ks="/k.jks")
+
+    assert captured["stdout"] is None
+    assert captured["input"] is None
+
+
+def test_signer_keeps_the_pipe_when_both_passwords_are_given(monkeypatch):
+    """With nothing left to prompt for there is no reason to give up stdout"""
+    captured = {}
+    monkeypatch.setattr(cli, "download_signer", lambda: "/signer.jar")
+    monkeypatch.setattr("sys.stdin", FakeStdin(tty=True))
+    monkeypatch.setattr(cli.subprocess, "Popen", _popen_recorder(captured))
+
+    cli.sign_apk("/out/app.apk", ks="/k.jks", ks_pass="a", ks_key_pass="b")
+
+    assert captured["stdout"] is subprocess.PIPE
+
+
+def _popen_recorder(captured):
+    """Build a Popen stand-in recording how the signer was wired up"""
+
+    class FakeProcess:
+        """Reports a successful, silent run"""
+
+        returncode = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def communicate(self, data=None):
+            """Record what was written to the signer"""
+            captured["input"] = data
+            return (b"", None)
+
+    def popen(cmd, stdin=None, stdout=None, stderr=None):
+        """Record the streams the signer was given"""
+        captured.update(cmd=cmd, stdin=stdin, stdout=stdout, stderr=stderr)
+        return FakeProcess()
+
+    return popen
+
+
+# --- delayed javascript --------------------------------------------------
+
+
+def test_delayed_script_is_written_outside_the_source_directory(tmp_path):
+    """The user's own files must not be overwritten or required to be writable"""
+    source = tmp_path / "hook.js"
+    source.write_text("console.log('x');", encoding="utf-8")
+    bystander = tmp_path / "hook_wrapped.js"
+    bystander.write_text("keep me", encoding="utf-8")
+
+    wrapped = cli.wrap_js_file(str(source), 3)
+
+    assert cli.Path(wrapped).parent != tmp_path
+    assert bystander.read_text(encoding="utf-8") == "keep me"
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["hook.js", "hook_wrapped.js"]
+
+    contents = cli.Path(wrapped).read_text(encoding="utf-8")
+    assert "console.log('x');" in contents
+    assert "}, 3000);" in contents
+
+
+def test_delay_requires_a_script():
+    """--js-delay on its own has nothing to wrap"""
+    with pytest.raises(SystemExit):
+        cli.wrap_js_file(None, 3)
+
+
+def test_negative_delay_is_rejected():
+    """A negative timeout would run the script immediately"""
+    with pytest.raises(SystemExit):
+        cli.wrap_js_file("hook.js", -1)
+
+
+def test_missing_script_is_reported(tmp_path):
+    """A path that does not exist stops the run"""
+    with pytest.raises(SystemExit):
+        cli.wrap_js_file(str(tmp_path / "absent.js"), 1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from scripts import cli
 class FakeStdin:  # pylint: disable=too-few-public-methods
     """Stand-in for sys.stdin with a controllable isatty()."""
     def __init__(self, tty):
+        """Record whether this stream should look like a terminal."""
         self.tty = tty
 
     def isatty(self):
@@ -64,7 +65,7 @@ def test_unrelated_directory_is_not_reusable(tmp_path):
 
 
 def test_regular_file_is_not_reusable(tmp_path):
-    """rmtree cannot be pointed at a file."""
+    """A file cannot be handed to rmtree."""
     target = tmp_path / "plain"
     target.write_text("x", encoding="utf-8")
     assert cli.is_reusable_decompile_dir(target) is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for scripts.cli"""
+"""Tests for scripts.cli."""
 import io
 import json
 import subprocess
@@ -9,13 +9,12 @@ from scripts import cli
 
 
 class FakeStdin:  # pylint: disable=too-few-public-methods
-    """Stand-in for sys.stdin with a controllable isatty()"""
-
+    """Stand-in for sys.stdin with a controllable isatty()."""
     def __init__(self, tty):
         self.tty = tty
 
     def isatty(self):
-        """Report whether this stream is a terminal"""
+        """Report whether this stream is a terminal."""
         return self.tty
 
 
@@ -35,7 +34,7 @@ class FakeStdin:  # pylint: disable=too-few-public-methods
     ],
 )
 def test_decompile_target_stays_next_to_the_apk(tmp_path, name, expected):
-    """The decompile directory is a sibling of the APK, never its parent"""
+    """The decompile directory is a sibling of the APK, never its parent."""
     apk = tmp_path / name
     apk.write_bytes(b"PK\x03\x04")
 
@@ -47,25 +46,25 @@ def test_decompile_target_stays_next_to_the_apk(tmp_path, name, expected):
 
 
 def test_empty_directory_is_reusable(tmp_path):
-    """Nothing can be lost by removing an empty directory"""
+    """Nothing can be lost by removing an empty directory."""
     assert cli.is_reusable_decompile_dir(tmp_path) is True
 
 
 @pytest.mark.parametrize("marker", ["apktool.yml", "AndroidManifest.xml", "smali"])
 def test_apktool_output_is_reusable(tmp_path, marker):
-    """A previous decompile, complete or interrupted, may be replaced"""
+    """A previous decompile, complete or interrupted, may be replaced."""
     (tmp_path / marker).write_text("x", encoding="utf-8")
     assert cli.is_reusable_decompile_dir(tmp_path) is True
 
 
 def test_unrelated_directory_is_not_reusable(tmp_path):
-    """A directory that merely shares the APK name must survive"""
+    """A directory that merely shares the APK name must survive."""
     (tmp_path / "holiday.jpg").write_text("x", encoding="utf-8")
     assert cli.is_reusable_decompile_dir(tmp_path) is False
 
 
 def test_regular_file_is_not_reusable(tmp_path):
-    """rmtree cannot be pointed at a file"""
+    """rmtree cannot be pointed at a file."""
     target = tmp_path / "plain"
     target.write_text("x", encoding="utf-8")
     assert cli.is_reusable_decompile_dir(target) is False
@@ -75,7 +74,7 @@ def test_regular_file_is_not_reusable(tmp_path):
 
 
 def test_decompile_options_carry_the_flags(tmp_path):
-    """The apktool command line reflects the CLI flags"""
+    """The apktool command line reflects the CLI flags."""
     options, no_res = cli.build_decompile_options(tmp_path, True, True, None)
 
     assert options[:2] == ["d", "-o"]
@@ -86,7 +85,7 @@ def test_decompile_options_carry_the_flags(tmp_path):
 
 
 def test_no_res_is_not_passed_twice(tmp_path):
-    """--no-res given both ways still reaches apktool once"""
+    """--no-res given both ways still reaches apktool once."""
     options, no_res = cli.build_decompile_options(tmp_path, False, True, "--no-res")
 
     assert options.count("--no-res") == 1
@@ -94,7 +93,7 @@ def test_no_res_is_not_passed_twice(tmp_path):
 
 
 def test_no_res_in_decompile_opts_updates_the_flag(tmp_path):
-    """--decompile-opts can turn on no_res for the injection step"""
+    """--decompile-opts can turn on no_res for the injection step."""
     options, no_res = cli.build_decompile_options(tmp_path, False, False, "--no-res")
 
     assert options.count("--no-res") == 1
@@ -102,20 +101,20 @@ def test_no_res_in_decompile_opts_updates_the_flag(tmp_path):
 
 
 def test_apktool_falls_back_to_the_one_on_path(monkeypatch):
-    """Without --apktool-path the command found on PATH is used"""
+    """Without --apktool-path the command found on PATH is used."""
     monkeypatch.setattr(cli, "APKTOOL", "/usr/local/bin/apktool")
     assert cli.resolve_apktool(None) == "/usr/local/bin/apktool"
 
 
 def test_missing_apktool_is_reported(monkeypatch):
-    """Without apktool anywhere the run cannot start"""
+    """Without apktool anywhere the run cannot start."""
     monkeypatch.setattr(cli, "APKTOOL", None)
     with pytest.raises(FileNotFoundError):
         cli.resolve_apktool(None)
 
 
 def test_apktool_path_must_exist():
-    """A missing --apktool-path is reported instead of failing later"""
+    """A missing --apktool-path is reported instead of failing later."""
     with pytest.raises(SystemExit):
         cli.resolve_apktool("/nonexistent/apktool")
 
@@ -134,18 +133,18 @@ def test_apktool_path_must_exist():
     ],
 )
 def test_arch_aliases(given, expected):
-    """Device ABI names are accepted alongside the short names"""
+    """Device ABI names are accepted alongside the short names."""
     assert cli.normalize_arch(given, False) == expected
 
 
 def test_unsupported_arch_is_rejected():
-    """An architecture we cannot download a gadget for stops the run"""
+    """An architecture we cannot download a gadget for stops the run."""
     with pytest.raises(SystemExit):
         cli.validate_arch("mips")
 
 
 def test_multi_arch_skips_validation():
-    """'multi-arch' is resolved from the APK later on"""
+    """'multi-arch' is resolved from the APK later on."""
     assert cli.validate_arch("multi-arch") == "multi-arch"
 
 
@@ -153,34 +152,34 @@ def test_multi_arch_skips_validation():
 
 
 def test_custom_gadget_name_wins():
-    """--custom-gadget-name decides the library name"""
+    """--custom-gadget-name decides the library name."""
     assert cli.resolve_gadget_name("/x/frida.so", "mygadget", "arm64") == "mygadget.so"
 
 
 def test_custom_gadget_name_applies_to_multi_arch():
-    """One name resolves in every lib/<abi>, so it works for multi-arch too"""
+    """One name resolves in every lib/<abi>, so it works for multi-arch too."""
     assert cli.resolve_gadget_name("/x/frida.so", "mygadget", "multi-arch") == "mygadget.so"
 
 
 def test_multi_arch_uses_an_architecture_free_name():
-    """The downloaded name carries the ABI, which loadLibrary cannot use"""
+    """The downloaded name carries the ABI, which loadLibrary cannot use."""
     name = cli.resolve_gadget_name("/x/frida-gadget-17-android-arm64.so", None, "multi-arch")
     assert name == "libfrida-gadget.so"
 
 
 def test_downloaded_gadget_keeps_its_name():
-    """Without overrides the downloaded file name is used as-is"""
+    """Without overrides the downloaded file name is used as-is."""
     assert cli.resolve_gadget_name("/x/frida-gadget.so", None, "arm64") == "frida-gadget.so"
 
 
 def test_unknown_architecture_has_no_abi_directory(tmp_path):
-    """An ABI directory we do not know about is refused"""
+    """An ABI directory we do not know about is refused."""
     with pytest.raises(NotImplementedError):
         cli.prepare_lib_dir(tmp_path, "mips")
 
 
 def test_lib_directory_is_created(tmp_path):
-    """lib/<abi> is created even when the APK ships no native libraries"""
+    """lib/<abi> is created even when the APK ships no native libraries."""
     lib_dir = cli.prepare_lib_dir(tmp_path, "arm64")
     assert lib_dir == tmp_path / "lib" / "arm64-v8a"
     assert lib_dir.is_dir()
@@ -190,7 +189,7 @@ def test_lib_directory_is_created(tmp_path):
 
 
 def test_config_is_generated_for_a_script(tmp_path):
-    """--js alone produces a config pointing at the uploaded script"""
+    """--js alone produces a config pointing at the uploaded script."""
     upload_files = {"config": None, "script": "s.js"}
     cli.write_gadget_config(None, "s.js", tmp_path, "libfoo", upload_files)
 
@@ -200,7 +199,7 @@ def test_config_is_generated_for_a_script(tmp_path):
 
 
 def test_supplied_config_gets_the_script_path_rewritten(tmp_path):
-    """The path in the user's config is replaced by the uploaded name"""
+    """The path in the user's config is replaced by the uploaded name."""
     config = tmp_path / "gadget.json"
     config.write_text(
         json.dumps({"interaction": {"type": "script", "path": "/data/local/tmp/a.js"}}),
@@ -216,7 +215,7 @@ def test_supplied_config_gets_the_script_path_rewritten(tmp_path):
 
 
 def test_config_without_script_is_uploaded_untouched(tmp_path):
-    """Without --js the config is left for the upload step to copy"""
+    """Without --js the config is left for the upload step to copy."""
     config = tmp_path / "gadget.json"
     config.write_text(
         json.dumps({"interaction": {"type": "listen", "address": "127.0.0.1"}}),
@@ -231,7 +230,7 @@ def test_config_without_script_is_uploaded_untouched(tmp_path):
 
 
 def test_config_must_declare_an_interaction(tmp_path):
-    """A config frida cannot act on stops the run"""
+    """A config frida cannot act on stops the run."""
     config = tmp_path / "gadget.json"
     config.write_text(json.dumps({}), encoding="utf-8")
 
@@ -240,7 +239,7 @@ def test_config_must_declare_an_interaction(tmp_path):
 
 
 def test_script_config_must_declare_a_path(tmp_path):
-    """'type: script' without a path would leave the gadget idle"""
+    """'type: script' without a path would leave the gadget idle."""
     config = tmp_path / "gadget.json"
     config.write_text(json.dumps({"interaction": {"type": "script"}}), encoding="utf-8")
 
@@ -261,7 +260,7 @@ ONCREATE_SMALI = [
 
 
 def test_load_library_call_is_inserted_into_oncreate():
-    """The call lands right after the .locals declaration"""
+    """The call lands right after the .locals declaration."""
     text = list(ONCREATE_SMALI)
 
     assert cli.insert_load_library_call(text, "libfrida-gadget") is True
@@ -270,7 +269,7 @@ def test_load_library_call_is_inserted_into_oncreate():
 
 
 def test_locals_zero_is_raised_to_one():
-    """A method with no registers gets one for the library name"""
+    """A method with no registers gets one for the library name."""
     text = [
         ".method protected onCreate(Landroid/os/Bundle;)V",
         "    .locals 0",
@@ -282,7 +281,7 @@ def test_locals_zero_is_raised_to_one():
 
 
 def test_method_without_locals_is_skipped():
-    """Without a .locals declaration there is no register to use"""
+    """Without a .locals declaration there is no register to use."""
     text = [
         ".method protected onCreate(Landroid/os/Bundle;)V",
         "    return-void",
@@ -297,19 +296,19 @@ def test_method_without_locals_is_skipped():
 
 
 def test_no_entrypoint_reports_failure():
-    """A class without onCreate or <init> cannot be patched"""
+    """A class without onCreate or <init> cannot be patched."""
     assert cli.insert_load_library_call([".class public Lcom/e/Main;"], "libfoo") is False
 
 
 def test_trailing_method_declaration_does_not_crash():
-    """A truncated smali file must not raise IndexError"""
+    """A truncated smali file must not raise IndexError."""
     assert cli.insert_load_library_call(
         [".method protected onCreate(Landroid/os/Bundle;)V"], "libfoo"
     ) is False
 
 
 def test_activity_smali_is_found_in_a_split_dex(tmp_path):
-    """Classes live in smali_classes<N> once the APK is multidex"""
+    """Classes live in smali_classes<N> once the APK is multidex."""
     target = tmp_path / "smali_classes3" / "com" / "e" / "Main.smali"
     target.parent.mkdir(parents=True)
     target.write_text(".class public Lcom/e/Main;", encoding="utf-8")
@@ -321,7 +320,7 @@ def test_activity_smali_is_found_in_a_split_dex(tmp_path):
 
 
 def test_activity_smali_in_the_primary_dex_has_no_number(tmp_path):
-    """The plain 'smali' directory maps to classes.dex"""
+    """The plain 'smali' directory maps to classes.dex."""
     target = tmp_path / "smali" / "com" / "e" / "Main.smali"
     target.parent.mkdir(parents=True)
     target.write_text(".class public Lcom/e/Main;", encoding="utf-8")
@@ -330,7 +329,7 @@ def test_activity_smali_in_the_primary_dex_has_no_number(tmp_path):
 
 
 def test_missing_activity_smali_is_reported(tmp_path):
-    """A class apktool never produced stops the run"""
+    """A class apktool never produced stops the run."""
     (tmp_path / "smali").mkdir()
     with pytest.raises(FileNotFoundError):
         cli.find_activity_smali(tmp_path, "com.e.Missing")
@@ -340,7 +339,7 @@ def test_missing_activity_smali_is_reported(tmp_path):
 
 
 def test_passwords_are_redacted():
-    """A failing signer must not print the keystore passwords"""
+    """A failing signer must not print the keystore passwords."""
     cmd = ["java", "--ks", "/k.jks", "--ksKeyPass", "hunter2", "--ksPass", "s3cr3t"]
 
     redacted = cli.redact_passwords(cmd)
@@ -352,24 +351,22 @@ def test_passwords_are_redacted():
 
 
 def test_redaction_survives_a_trailing_flag():
-    """A flag without its value must not walk off the end of the list"""
+    """A flag without its value must not walk off the end of the list."""
     assert cli.redact_passwords(["java", "--ksPass"]) == ["java", "--ksPass"]
 
 
 def test_stdin_without_a_terminal(monkeypatch):
-    """A pipe cannot answer a password prompt"""
+    """A pipe cannot answer a password prompt."""
     monkeypatch.setattr("sys.stdin", io.StringIO())
     assert cli.stdin_is_interactive() is False
 
 
 def test_stdin_that_was_closed(monkeypatch):
-    """A closed stream raises rather than answering isatty()"""
-
+    """A closed stream raises rather than answering isatty()."""
     class Closed:  # pylint: disable=too-few-public-methods
-        """Raises the way a closed file object does"""
-
+        """Raises the way a closed file object does."""
         def isatty(self):
-            """Fail the way a closed stream does"""
+            """Fail the way a closed stream does."""
             raise ValueError("I/O operation on closed file")
 
     monkeypatch.setattr("sys.stdin", Closed())
@@ -377,13 +374,13 @@ def test_stdin_that_was_closed(monkeypatch):
 
 
 def test_missing_stdin(monkeypatch):
-    """Windowed interpreters can leave sys.stdin unset"""
+    """Windowed interpreters can leave sys.stdin unset."""
     monkeypatch.setattr("sys.stdin", None)
     assert cli.stdin_is_interactive() is False
 
 
 def test_signer_keeps_the_pipe_without_a_terminal(monkeypatch):
-    """Handing over a stdin nobody can type into would hang the run"""
+    """Handing over a stdin nobody can type into would hang the run."""
     captured = {}
     monkeypatch.setattr(cli, "download_signer", lambda: "/signer.jar")
     monkeypatch.setattr("sys.stdin", FakeStdin(tty=False))
@@ -396,7 +393,7 @@ def test_signer_keeps_the_pipe_without_a_terminal(monkeypatch):
 
 
 def test_signer_gets_the_terminal_when_there_is_one(monkeypatch):
-    """uber-apk-signer prompts for the passwords it was not given"""
+    """uber-apk-signer prompts for the passwords it was not given."""
     captured = {}
     monkeypatch.setattr(cli, "download_signer", lambda: "/signer.jar")
     monkeypatch.setattr("sys.stdin", FakeStdin(tty=True))
@@ -409,7 +406,7 @@ def test_signer_gets_the_terminal_when_there_is_one(monkeypatch):
 
 
 def test_signer_keeps_the_pipe_when_both_passwords_are_given(monkeypatch):
-    """With nothing left to prompt for there is no reason to give up stdout"""
+    """With nothing left to prompt for there is no reason to give up stdout."""
     captured = {}
     monkeypatch.setattr(cli, "download_signer", lambda: "/signer.jar")
     monkeypatch.setattr("sys.stdin", FakeStdin(tty=True))
@@ -421,11 +418,9 @@ def test_signer_keeps_the_pipe_when_both_passwords_are_given(monkeypatch):
 
 
 def _popen_recorder(captured):
-    """Build a Popen stand-in recording how the signer was wired up"""
-
+    """Build a Popen stand-in recording how the signer was wired up."""
     class FakeProcess:
-        """Reports a successful, silent run"""
-
+        """Reports a successful, silent run."""
         returncode = 0
 
         def __enter__(self):
@@ -435,12 +430,12 @@ def _popen_recorder(captured):
             return False
 
         def communicate(self, data=None):
-            """Record what was written to the signer"""
+            """Record what was written to the signer."""
             captured["input"] = data
             return (b"", None)
 
     def popen(cmd, stdin=None, stdout=None, stderr=None):
-        """Record the streams the signer was given"""
+        """Record the streams the signer was given."""
         captured.update(cmd=cmd, stdin=stdin, stdout=stdout, stderr=stderr)
         return FakeProcess()
 
@@ -451,7 +446,7 @@ def _popen_recorder(captured):
 
 
 def test_delayed_script_is_written_outside_the_source_directory(tmp_path):
-    """The user's own files must not be overwritten or required to be writable"""
+    """The user's own files must not be overwritten or required to be writable."""
     source = tmp_path / "hook.js"
     source.write_text("console.log('x');", encoding="utf-8")
     bystander = tmp_path / "hook_wrapped.js"
@@ -469,18 +464,18 @@ def test_delayed_script_is_written_outside_the_source_directory(tmp_path):
 
 
 def test_delay_requires_a_script():
-    """--js-delay on its own has nothing to wrap"""
+    """--js-delay on its own has nothing to wrap."""
     with pytest.raises(SystemExit):
         cli.wrap_js_file(None, 3)
 
 
 def test_negative_delay_is_rejected():
-    """A negative timeout would run the script immediately"""
+    """A negative timeout would run the script immediately."""
     with pytest.raises(SystemExit):
         cli.wrap_js_file("hook.js", -1)
 
 
 def test_missing_script_is_reported(tmp_path):
-    """A path that does not exist stops the run"""
+    """A path that does not exist stops the run."""
     with pytest.raises(SystemExit):
         cli.wrap_js_file(str(tmp_path / "absent.js"), 1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@
 import io
 import json
 import subprocess
+import tempfile
+import zipfile
 
 import pytest
 
@@ -480,3 +482,91 @@ def test_missing_script_is_reported(tmp_path):
     """A path that does not exist stops the run."""
     with pytest.raises(SystemExit):
         cli.wrap_js_file(str(tmp_path / "absent.js"), 1)
+
+
+# --- restoring the original dex files ------------------------------------
+
+
+def build_apk(path, entries):
+    """Write a zip holding the given name to bytes mapping."""
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, data in entries.items():
+            archive.writestr(name, data)
+    return path
+
+
+def read_apk(path):
+    """Read a zip back into a name to bytes mapping."""
+    with zipfile.ZipFile(path) as archive:
+        return {i.filename: archive.read(i.filename) for i in archive.infolist()}
+
+
+def test_only_the_patched_dex_comes_from_the_rebuild(tmp_path):
+    """Every other dex is taken from the original APK, resources from the rebuild."""
+    original = build_apk(
+        tmp_path / "app.apk",
+        {
+            "classes.dex": b"orig-1",
+            "classes2.dex": b"orig-2",
+            "classes3.dex": b"orig-3",
+            "res/layout.xml": b"orig-res",
+        },
+    )
+    recompiled = build_apk(
+        tmp_path / "rebuilt.apk",
+        {
+            "classes.dex": b"rebuilt-1",
+            "classes2.dex": b"rebuilt-2",
+            "classes3.dex": b"rebuilt-3",
+            "res/layout.xml": b"rebuilt-res",
+        },
+    )
+
+    cli.restore_original_dex(original, recompiled, 2)
+
+    result = read_apk(recompiled)
+    assert result["classes2.dex"] == b"rebuilt-2", "the patched dex must survive"
+    assert result["classes.dex"] == b"orig-1"
+    assert result["classes3.dex"] == b"orig-3"
+    assert result["res/layout.xml"] == b"rebuilt-res"
+
+
+@pytest.mark.parametrize("number", [None, 1])
+def test_the_primary_dex_is_the_default_target(tmp_path, number):
+    """smali/ and smali_classes1/ both map to classes.dex."""
+    original = build_apk(tmp_path / "app.apk", {"classes.dex": b"orig", "classes2.dex": b"orig-2"})
+    recompiled = build_apk(
+        tmp_path / f"rebuilt{number}.apk", {"classes.dex": b"new", "classes2.dex": b"new-2"}
+    )
+
+    cli.restore_original_dex(original, recompiled, number)
+
+    result = read_apk(recompiled)
+    assert result["classes.dex"] == b"new"
+    assert result["classes2.dex"] == b"orig-2"
+
+
+def test_a_failure_leaves_the_rebuilt_apk_alone(tmp_path):
+    """Restoring is best effort, so a broken original must not lose the rebuild."""
+    broken = tmp_path / "app.apk"
+    broken.write_bytes(b"not a zip at all")
+    recompiled = build_apk(tmp_path / "rebuilt.apk", {"classes.dex": b"new"})
+
+    cli.restore_original_dex(broken, recompiled, None)
+
+    assert read_apk(recompiled) == {"classes.dex": b"new"}
+
+
+def test_no_temporary_file_is_left_behind(tmp_path, monkeypatch):
+    """A failure part way through must not strand a staged APK in the temp dir."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(staging))
+
+    original = build_apk(tmp_path / "app.apk", {"classes.dex": b"orig"})
+    recompiled = build_apk(tmp_path / "rebuilt.apk", {"classes.dex": b"new", "classes9.dex": b"x"})
+
+    # classes9.dex is missing from the original, so the copy raises part way
+    cli.restore_original_dex(original, recompiled, None)
+
+    assert not list(staging.iterdir())

--- a/tests/test_frida_github.py
+++ b/tests/test_frida_github.py
@@ -1,4 +1,4 @@
-"""Tests for scripts.frida_github"""
+"""Tests for scripts.frida_github."""
 import pytest
 
 from scripts.frida_github import FridaGithub
@@ -20,7 +20,7 @@ DEFAULT = "https://api.github.com/repos/frida/frida"
     ],
 )
 def test_accepted_repository_references(reference):
-    """Every way of naming a github.com repository resolves the same"""
+    """Every way of naming a github.com repository resolves the same."""
     expected = "https://api.github.com/repos/myuser/my-frida-fork"
     assert FridaGithub.parse_repo(reference) == expected
 
@@ -38,19 +38,19 @@ def test_accepted_repository_references(reference):
     ],
 )
 def test_rejected_repository_references(reference):
-    """Anything that is not a github.com owner/repo is refused"""
+    """Anything that is not a github.com owner/repo is refused."""
     with pytest.raises(ValueError):
         FridaGithub.parse_repo(reference)
 
 
 def test_default_repository():
-    """Without --github-repo the upstream frida releases are used"""
+    """Without --github-repo the upstream frida releases are used."""
     assert FridaGithub.parse_repo("") == DEFAULT
     assert FridaGithub().github_api_base == DEFAULT
 
 
 def test_release_endpoints_follow_the_repository():
-    """Both endpoints are derived from the selected repository"""
+    """Both endpoints are derived from the selected repository."""
     github = FridaGithub("17.0.0", "myuser/fork")
 
     assert github.latest_release_url.endswith("/myuser/fork/releases/latest")
@@ -60,5 +60,5 @@ def test_release_endpoints_follow_the_repository():
 
 
 def test_gadget_version_is_kept():
-    """The version selects which release the assets come from"""
+    """The version selects which release the assets come from."""
     assert FridaGithub("17.0.0").gadget_version == "17.0.0"

--- a/tests/test_frida_github.py
+++ b/tests/test_frida_github.py
@@ -1,0 +1,64 @@
+"""Tests for scripts.frida_github"""
+import pytest
+
+from scripts.frida_github import FridaGithub
+
+DEFAULT = "https://api.github.com/repos/frida/frida"
+
+
+@pytest.mark.parametrize(
+    "reference",
+    [
+        "myuser/my-frida-fork",
+        "github.com/myuser/my-frida-fork",
+        "https://github.com/myuser/my-frida-fork",
+        "http://github.com/myuser/my-frida-fork",
+        "https://www.github.com/myuser/my-frida-fork",
+        "https://github.com/myuser/my-frida-fork/",
+        "https://github.com/myuser/my-frida-fork.git",
+        "  myuser/my-frida-fork  ",
+    ],
+)
+def test_accepted_repository_references(reference):
+    """Every way of naming a github.com repository resolves the same"""
+    expected = "https://api.github.com/repos/myuser/my-frida-fork"
+    assert FridaGithub.parse_repo(reference) == expected
+
+
+@pytest.mark.parametrize(
+    "reference",
+    [
+        "https://evil.com/frida/frida",
+        "evil.com/frida/frida",
+        "http://gitlab.com/a/b",
+        "justrepo",
+        "owner/repo/extra",
+        "https://github.com/onlyowner",
+        "/leading/slash",
+    ],
+)
+def test_rejected_repository_references(reference):
+    """Anything that is not a github.com owner/repo is refused"""
+    with pytest.raises(ValueError):
+        FridaGithub.parse_repo(reference)
+
+
+def test_default_repository():
+    """Without --github-repo the upstream frida releases are used"""
+    assert FridaGithub.parse_repo("") == DEFAULT
+    assert FridaGithub().github_api_base == DEFAULT
+
+
+def test_release_endpoints_follow_the_repository():
+    """Both endpoints are derived from the selected repository"""
+    github = FridaGithub("17.0.0", "myuser/fork")
+
+    assert github.latest_release_url.endswith("/myuser/fork/releases/latest")
+    assert github.tagged_release_url.format(tag="17.0.0").endswith(
+        "/myuser/fork/releases/tags/17.0.0"
+    )
+
+
+def test_gadget_version_is_kept():
+    """The version selects which release the assets come from"""
+    assert FridaGithub("17.0.0").gadget_version == "17.0.0"


### PR DESCRIPTION
Works through the open SonarCloud issues and the Codacy report, and puts a test suite underneath the result. `pylint` goes from 9.01 to 9.99.

### Bugs this turned up

| | |
|---|---|
| `run_apktool` | Removed entries from the list it was iterating over, so when both `--no-res` and `--use-aapt2` were already in use the failure message silently dropped one. |
| Every file read and write | No explicit encoding. Smali sources, gadget configs and hook scripts are UTF-8, but the default is cp949/cp1252 on Windows — non-ASCII content was mangled there. |
| `restore_original_dex` | Leaked both zip handles and the staged `NamedTemporaryFile` whenever repacking raised. On Windows the leaked handle also keeps the APK locked. |
| Failed recompile | Only logged `APK not found` and carried on to repack and **sign** an APK that was not there. |
| `insert_load_library_call` | Read past the end of a smali file ending on a `.method` line. |

### SonarCloud

All nine Python issues, and the ten Dockerfile issues.

- **S3776 ×5** — `get_main_activity` (67), `run` (88), `inject_gadget_into_apk` (46), `insert_loadlibary` (37), `sign_apk` (18). Split into named helpers rather than restructured.
- **S107** — `run` has one parameter per CLI flag; the count is dictated by click, so it carries a justified suppression instead of a fake fix.
- **S100 ×2** — `GITHUB_LATEST_RELEASE` / `GITHUB_TAGGED_RELEASE` are now `latest_release_url` / `tagged_release_url`.
- **S117** — `activityEnabled`, gone with the rewrite.
- **S1135** — the `TODO: custom gadget name for multi-arch` is implemented rather than deleted, see below.
- **S2083** — already fixed in #40; it should clear on the next analysis of trunk.

`apk_utils` also stops reaching into androguard's private `APK._ns` and reads manifest attributes through a module constant.

### Codacy

Codacy's Documentation category turned out to be pydocstyle rules about the *shape* of the docstrings, not missing ones — D400 (summary lines ending in a period) alone accounted for 24 of them before this branch. Adding roughly fifty helpers took that to 49, so the whole tree is normalised: summary lines end in a period, over-indented and space-padded docstrings are re-indented, the blank line after a function docstring is dropped while the one after a class docstring is kept, and `Gets`/`Function to` become imperative. `pydocstyle` now reports nothing across `scripts/` and `tests/`.

The long lines, trailing whitespace and missing final newlines are gone too.

### Two deliberate behaviour changes

1. The config generated for a bare `--js` is written with `json.dumps`. It parses to exactly the same object; only the stray whitespace the old hand-built string emitted is gone.
2. `--custom-gadget-name` now applies to `--arch multi-arch`. That was the standing TODO — the name was being forced to `libfrida-gadget.so` because the *downloaded* file name carries the ABI, but a name the user supplies does not. The same name is written into every `lib/<abi>` directory, so one `System.loadLibrary` call still resolves per ABI.

### Verification

The refactor is large, so it was checked against the pre-refactor code rather than by inspection.

- `inject_gadget_into_apk` was run on a synthetic decompiled APK on both revisions across nine scenarios — plain, `--js`, `--config`, both, a `listen`-type config, `multi-arch`, and `--custom-gadget-name` in each combination — comparing the resulting file tree, every file hash, the patched smali and the manifest. Six are byte-identical; the three that differ are the generated config above, whose parsed JSON matches exactly.
- `get_main_activity` was run on both revisions over eleven manifests — aliases, disabled activities, multiple mains, split manifests, missing names — with no difference.
- 85 new tests, run against the final tree.

### Tests

`tests/test_cli.py` invoked the CLI against `tests/demo-apk/handtrackinggpu.apk`, which is not in the repository, so the suite could never run. It is replaced with unit tests over the extracted helpers, plus `test_apk_utils.py` and `test_frida_github.py`. The manifest fixtures assert the hardcoded android namespace still agrees with androguard's, so drift on their side surfaces in CI rather than at runtime.

### Left alone

- The three `docker:S8544` findings — pip installing without pinned versions — are left as they are, on the maintainer's call. They already existed on trunk, but restructuring those lines re-attributes them to new code, so **the SonarCloud quality gate on this PR stays red on `new_security_rating`**. They are the only issues left; resolving them in the SonarCloud UI clears the gate.
- `scripts/cli.py` is still 1346 lines, over pylint's 1000 default. Splitting it (`signing.py`, `smali.py`, `apktool.py`) is the obvious next step but is a separate, larger diff — say the word and I'll do it.
- `requirements.txt` pins nothing and pulls `pytest`, `pylint` and `coverage` into the Docker image. Worth separating dev and runtime dependencies, also separately.
- There is no CI running the tests. They pass locally with `python -m pytest tests/`.
