### PR TITLE
Stop running pip on import, and declare frida as a dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,11 @@ RUN curl -fsSL --proto '=https' --tlsv1.2 \
 RUN useradd -m -s /bin/bash frida-user
 
 # Install python dependencies. '--only-binary :all:' installs wheels only, so no
-# package can run setup code while the image is being built. frida is imported
-# by scripts/__init__.py to read the version the gadget is matched against.
+# package can run setup code while the image is being built. frida is listed in
+# requirements.txt, so it no longer needs a line of its own.
 WORKDIR /workspace
 COPY requirements.txt /workspace/requirements.txt
 RUN pip3 install --no-cache-dir --only-binary :all: --upgrade pip && \
-    pip3 install --no-cache-dir --only-binary :all: frida && \
     pip3 install --no-cache-dir --only-binary :all: -r requirements.txt
 
 COPY scripts /workspace/scripts

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+coverage
+pydocstyle
+pylint
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
-click
 androguard >= 4.0.0
-apk-signer
-pytest
+click
 colorlog
-coverage
-pylint
+frida
 requests

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,10 +1,11 @@
 """init file for scripts folder."""
+from typing import Optional
 
 try:
     import frida
 
-    INSTALLED_FRIDA_VERSION: str = frida.__version__
+    INSTALLED_FRIDA_VERSION: Optional[str] = frida.__version__
 except ImportError:
     # frida is only read to work out which gadget release to download, so the
     # tool still works without it as long as --frida-version says which one.
-    INSTALLED_FRIDA_VERSION: str = None
+    INSTALLED_FRIDA_VERSION = None

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,22 +1,10 @@
 """init file for scripts folder."""
-import sys
-import subprocess
-from .logger import logger
 
+try:
+    import frida
 
-def import_or_install(package):
-    """Install a package, or exit asking the user to try again.
-
-    Args:
-        package (string): Name of the package to install.
-    """
-    try:
-        __import__(package)
-    except ImportError:
-        subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'frida', '--user'])
-        logger.info('Try Again')
-        sys.exit(0)
-
-
-import_or_install('frida')  # Install missing packages
-INSTALLED_FRIDA_VERSION: str = __import__('frida').__version__  # Get installed frida version
+    INSTALLED_FRIDA_VERSION: str = frida.__version__
+except ImportError:
+    # frida is only read to work out which gadget release to download, so the
+    # tool still works without it as long as --frida-version says which one.
+    INSTALLED_FRIDA_VERSION: str = None

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -189,9 +189,16 @@ def download_gadget(
     if frida_version:
         logger.info("Using specified frida version: %s", frida_version)
         version = frida_version
-    else:
+    elif INSTALLED_FRIDA_VERSION:
         logger.info("Auto-detected your frida version: %s", INSTALLED_FRIDA_VERSION)
         version = INSTALLED_FRIDA_VERSION
+    else:
+        logger.error(
+            "frida is not installed, so the gadget version cannot be detected.\n"
+            "Install it with 'pip install frida', or name the release yourself "
+            "with the --frida-version option."
+        )
+        sys.exit(-1)
 
     if github_repo:
         logger.info("Using custom GitHub repository: %s", github_repo)

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,10 @@ with open("README.rst", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 requires = [
-    'click',
     'androguard >= 4.0.0',
-    'apk-signer',
-    'pytest',
+    'click',
     'colorlog',
-    'coverage',
+    'frida',
     'requests',
 ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -570,3 +570,58 @@ def test_no_temporary_file_is_left_behind(tmp_path, monkeypatch):
     cli.restore_original_dex(original, recompiled, None)
 
     assert not list(staging.iterdir())
+
+
+# --- frida version detection ---------------------------------------------
+
+
+def recording_github(asked):
+    """Build a FridaGithub stand-in that records the version it was given."""
+
+    class RecordingGithub:  # pylint: disable=too-few-public-methods
+        """Reports a release whose assets never match."""
+
+        def __init__(self, version, github_repo=""):
+            asked["version"] = version
+            asked["repo"] = github_repo
+
+        @staticmethod
+        def get_assets():
+            """Report a release with no matching asset."""
+            return []
+
+    return RecordingGithub
+
+
+def test_gadget_version_falls_back_to_the_installed_frida(monkeypatch, tmp_path):
+    """Without --frida-version the version frida reports is used."""
+    monkeypatch.setattr(cli, "INSTALLED_FRIDA_VERSION", "17.0.0")
+    monkeypatch.setattr(cli, "FILE_DIR", tmp_path)
+    asked = {}
+
+    monkeypatch.setattr(cli, "FridaGithub", recording_github(asked))
+    with pytest.raises(FileNotFoundError):
+        cli.download_gadget("arm64")
+
+    assert asked["version"] == "17.0.0"
+
+
+def test_missing_frida_asks_for_an_explicit_version(monkeypatch):
+    """Without frida installed the version has to be named on the command line."""
+    monkeypatch.setattr(cli, "INSTALLED_FRIDA_VERSION", None)
+
+    with pytest.raises(SystemExit):
+        cli.download_gadget("arm64")
+
+
+def test_explicit_version_works_without_frida(monkeypatch, tmp_path):
+    """--frida-version makes the frida package unnecessary."""
+    monkeypatch.setattr(cli, "INSTALLED_FRIDA_VERSION", None)
+    monkeypatch.setattr(cli, "FILE_DIR", tmp_path)
+    asked = {}
+
+    monkeypatch.setattr(cli, "FridaGithub", recording_github(asked))
+    with pytest.raises(FileNotFoundError):
+        cli.download_gadget("arm64", frida_version="16.1.3")
+
+    assert asked["version"] == "16.1.3"


### PR DESCRIPTION
`scripts/__init__.py` ran `pip install frida --user` from module scope whenever the import failed, then called `sys.exit(0)`.

That existed because `frida` was never listed in `install_requires`. Declaring it removes the reason for the hack.

### What the hack did

- **Ran pip as a side effect of importing the package.** Anything that touched `scripts` — the CLI, a test run, an editor's autocomplete — could start a network install.
- **`--user` fails inside a virtualenv**, which is where most people install this. It exits with `Can not perform a '--user' install. User site-packages are not visible in this virtualenv`, so the hack could not fix the very case it was written for.
- **`sys.exit(0)` reports success** while having done nothing the caller asked for, so a wrapping script sees a clean exit code.
- It installed `frida` regardless of which `package` name it was given.

### Instead

`frida` is read for one reason: to know which gadget release to download. So the import is now optional — without it `INSTALLED_FRIDA_VERSION` is `None`, and `--frida-version` names the release instead. Only when neither is available does the run stop, with a message saying which of the two to supply.

That also makes the tool usable offline against a fork or a pre-downloaded gadget without installing the frida bindings at all.

### Dependencies

`install_requires` listed `apk-signer`, `pytest` and `coverage`, none of which are imported anywhere in `scripts/`. It now lists exactly what the package imports:

`androguard`, `click`, `colorlog`, `frida`, `requests`

Development tools move to `requirements-dev.txt`, so `requirements.txt` — which the Dockerfile installs — no longer pulls pytest, pylint and coverage into the image. The Dockerfile's separate `pip install frida` line goes away with it.

### Verified

- Importing `scripts` with frida unavailable: no pip invocation, no `sys.exit`, `INSTALLED_FRIDA_VERSION` is `None`
- Importing it normally: `INSTALLED_FRIDA_VERSION` matches `frida.__version__`
- Three new tests — the installed version is used by default, `--frida-version` works without frida present, and neither one available stops the run
- 93 tests pass, pylint 9.99, pydocstyle clean