### PR TITLE
Clear the remaining SonarCloud findings, pin uber-apk-signer and lock the image deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,13 +30,15 @@ ADD --chmod=755 --checksum=sha256:${APKTOOL_SHA256} \
 # Create a non-root user
 RUN useradd -m -s /bin/bash frida-user
 
-# Install python dependencies. '--only-binary :all:' installs wheels only, so no
-# package can run setup code while the image is being built. frida is listed in
-# requirements.txt, so it no longer needs a line of its own.
+# Install python dependencies from the lock file, so a rebuild resolves to the
+# same versions rather than whatever is newest. '--only-binary :all:' installs
+# wheels only, so no package can run setup code while the image is being built.
+# setup.py keeps ranges instead; pinning a library's dependencies would force
+# them on everyone who installs frida-gadget.
 WORKDIR /workspace
-COPY requirements.txt /workspace/requirements.txt
-RUN pip3 install --no-cache-dir --only-binary :all: --upgrade pip && \
-    pip3 install --no-cache-dir --only-binary :all: -r requirements.txt
+COPY requirements.lock /workspace/requirements.lock
+RUN pip3 install --no-cache-dir --only-binary :all: pip==26.2.1 && \
+    pip3 install --no-cache-dir --only-binary :all: -r requirements.lock
 
 COPY scripts /workspace/scripts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM eclipse-temurin:17-jdk-jammy
 LABEL maintainer="ksg97031 <ksg97031@gmail.com>"
 
 ARG APKTOOL_VERSION=2.11.1
+# sha256 of apktool_${APKTOOL_VERSION}.jar. Bitbucket and the GitHub release
+# serve byte-identical files; override both together to move to a new version.
+ARG APKTOOL_SHA256=56d59c524fc764263ba8d345754d8daf55b1887818b15cd3b594f555d249e2db
 ENV APKTOOL_VERSION=${APKTOOL_VERSION}
 
 # Install dependencies
@@ -15,16 +18,14 @@ RUN apt-get update && \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install apktool. The launcher script and the jar are fetched over HTTPS with
-# --proto '=https' so a redirect cannot downgrade the transfer to plain HTTP.
-WORKDIR /usr/local/bin
-RUN curl -fsSL --proto '=https' --tlsv1.2 \
-        -o apktool \
-        https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/linux/apktool && \
-    curl -fsSL --proto '=https' --tlsv1.2 \
-        -o apktool.jar \
-        "https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_${APKTOOL_VERSION}.jar" && \
-    chmod +x apktool apktool.jar
+# Install apktool. ADD fetches over HTTPS and refuses a redirect to plain HTTP,
+# and the jar carries a checksum so a substituted artifact fails the build.
+ADD --chmod=755 \
+    https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/linux/apktool \
+    /usr/local/bin/apktool
+ADD --chmod=755 --checksum=sha256:${APKTOOL_SHA256} \
+    https://github.com/iBotPeaches/Apktool/releases/download/v${APKTOOL_VERSION}/apktool_${APKTOOL_VERSION}.jar \
+    /usr/local/bin/apktool.jar
 
 # Create a non-root user
 RUN useradd -m -s /bin/bash frida-user

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,0 +1,50 @@
+# Generated inside the image with `pip3 freeze` on linux, so the wheels match
+# what the Dockerfile installs. Regenerate when requirements.txt moves.
+# The library's own dependency ranges live in setup.py; this file only locks
+# the image so a rebuild resolves to the same versions.
+alembic==1.19.1
+androguard==4.1.4
+apkInspector==1.3.6
+asn1crypto==1.5.1
+asttokens==3.0.2
+certifi==2026.7.22
+cffi==2.1.1
+charset-normalizer==3.5.0
+click==8.4.2
+colorama==0.4.6
+colorlog==6.12.0
+cryptography==50.0.0
+dataset==2.0.0
+decorator==5.3.1
+exceptiongroup==1.3.1
+executing==2.2.1
+frida==17.17.0
+greenlet==3.5.5
+idna==3.18
+ipython==8.39.0
+jedi==0.20.0
+loguru==0.7.3
+lxml==6.1.1
+Mako==1.4.1
+MarkupSafe==3.0.3
+matplotlib-inline==0.2.2
+mutf8==1.1.0
+networkx==3.4.2
+parso==0.8.7
+pexpect==4.9.0
+prompt_toolkit==3.0.53
+ptyprocess==0.7.0
+pure_eval==0.2.3
+pycparser==3.0
+pydot==4.0.1
+Pygments==2.20.0
+pyparsing==3.3.2
+PyYAML==6.0.3
+requests==2.34.2
+SQLAlchemy==2.0.52
+stack-data==0.6.3
+tomli==2.4.1
+traitlets==5.16.1
+typing_extensions==4.16.0
+urllib3==2.7.0
+wcwidth==0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 androguard >= 4.0.0
-click
-colorlog
-frida
-requests
+click >= 8.0
+colorlog >= 6.0
+frida >= 16.0
+requests >= 2.25

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -390,8 +390,8 @@ def wrap_js_with_timeout(js_content: str, delay: int) -> str:
 )
 @click.argument("apk_path", type=click.Path(exists=True), required=True)
 # One parameter per CLI flag, so the count is dictated by the options above
-def run(  # NOSONAR
-    apk_path: str,
+def run(
+    apk_path: str,  # NOSONAR
     arch: str,
     config: str,
     no_res: bool,

--- a/scripts/uber_apk_signer_github.py
+++ b/scripts/uber_apk_signer_github.py
@@ -9,18 +9,25 @@ import requests
 class UberApkSignerGithub:
     """Interact with Github."""
 
-    GITHUB_LATEST_RELEASE = (
-        'https://api.github.com/repos/patrickfav/uber-apk-signer/releases/latest'
+    GITHUB_TAGGED_RELEASE = (
+        'https://api.github.com/repos/patrickfav/uber-apk-signer/releases/tags/v{tag}'
     )
+
+    # The signer is downloaded and then executed, so the release it comes from is
+    # pinned rather than resolved to whatever is newest. SIGNER_SHA256 is the hash
+    # the release publishes in checksum-sha256.txt, recorded here so a replaced
+    # release is rejected instead of trusted because it ships a matching checksum.
+    DEFAULT_SIGNER_VERSION = '1.3.0'
+    KNOWN_SIGNER_SHA256 = {
+        '1.3.0': 'e1299fd6fcf4da527dd53735b56127e8ea922a321128123b9c32d619bba1d835',
+    }
 
     # the 'context' of this Github instance
     signer_version = None
 
     def __init__(self, signer_version: str = None):
         """Init a new instance of Github."""
-        if signer_version:
-            self.signer_version = signer_version
-
+        self.signer_version = signer_version or self.DEFAULT_SIGNER_VERSION
         self.request_cache = {}
 
     def _call(self, endpoint: str) -> dict:
@@ -49,9 +56,7 @@ class UberApkSignerGithub:
 
         :return:
         """
-        assets = self._call(self.GITHUB_LATEST_RELEASE)
-
-        self.signer_version = assets['tag_name'][1:]
+        assets = self._call(self.GITHUB_TAGGED_RELEASE.format(tag=self.signer_version))
 
         if 'assets' not in assets:
             raise FileNotFoundError(
@@ -118,10 +123,12 @@ class UberApkSignerGithub:
             signer_data = signer_file.read()
             signer_hash = hashlib.sha256(signer_data).hexdigest()
 
-        if checksum != signer_hash:
+        expected = self.KNOWN_SIGNER_SHA256.get(self.signer_version, checksum)
+        if signer_hash not in (checksum, expected) or checksum != expected:
             os.remove(signer_fullpath)
             os.remove(check_sum_fullpath)
             raise ValueError(
-                'The downloaded uber-apk-signer-*.jar file does not match the checksum.')
+                f'uber-apk-signer {self.signer_version} does not match the expected '
+                f'sha256 {expected}, got {signer_hash}.')
 
         return signer_fullpath

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@ with open("README.rst", "r", encoding="utf-8") as fh:
 
 requires = [
     'androguard >= 4.0.0',
-    'click',
-    'colorlog',
-    'frida',
-    'requests',
+    'click >= 8.0',
+    'colorlog >= 6.0',
+    'frida >= 16.0',
+    'requests >= 2.25',
 ]
 
 setuptools.setup(


### PR DESCRIPTION
Three of the five open findings on trunk. The other two are the `docker:S8544` dependency-pinning pair on the pip lines, which you decided to leave.

### S107 — the NOSONAR was on the wrong line

Sonar anchors the finding to the parameter list at **line 394**, not to the `def run(` line above it where the comment sat, so the suppression never applied:

```
python:S107  scripts/cli.py:394  range=394-416
```

Moved onto the first parameter. The explanation stays as a comment above the definition.

### S7026 + S7031 — both pointed at the same RUN

`RUN curl ... && curl ... && chmod` became two `ADD` instructions. That satisfies S7026 and removes the RUN altogether, so S7031 ("merge this RUN with the consecutive ones") goes with it.

### The jar is now checksum-pinned

`ADD --checksum=sha256:...` on the apktool jar, with `APKTOOL_SHA256` as an ARG so it moves together with `APKTOOL_VERSION`.

The value is cross-checked rather than taken from one place — Bitbucket and the GitHub release serve byte-identical files:

```
bitbucket : 56d59c524fc764263ba8d345754d8daf55b1887818b15cd3b594f555d249e2db
github    : 56d59c524fc764263ba8d345754d8daf55b1887818b15cd3b594f555d249e2db
```

The download now points at the GitHub release, which is the same artifact over a host that also serves the wrapper script.

The wrapper script itself tracks `master` and has no stable hash, so it stays unpinned — same as before.

### Verified by building the image

- `docker build` succeeds
- `apktool --version` inside the image → `2.11.1`
- `sha256sum /usr/local/bin/apktool.jar` inside the image matches the pinned value
- `docker run ... --version` → `frida-gadget version 1.7.0`
- Building with a deliberately wrong checksum **fails**: `ERROR: digest mismatch sha256:56d59c52...: sha256:0000...` — so the gate is real, not decorative

93 tests pass, pylint 10.00/10.

---

## Also: uber-apk-signer pinned, and the image's dependencies locked

### The signer was floating

It is downloaded and then **executed** with `java -jar`, but it was resolved through `/releases/latest`, so the version could change under the tool at any time. Pinned to **1.3.0** through the tagged-release endpoint.

The `signer_version` constructor argument was dead code — `get_assets()` always overwrote it with the latest tag, so passing a version did nothing. It now selects the release.

The release publishes a checksum next to the jar, but that only proves the download was not corrupted in transit: a replaced release would ship a matching checksum. The expected sha256 is recorded in the code as well, so both have to agree. Cross-checked against the release's own `checksum-sha256.txt`:

```
e1299fd6fcf4da527dd53735b56127e8ea922a321128123b9c32d619bba1d835
```

Verified live: the download matches the pin, a deliberately wrong pin is rejected and the partial files are cleaned up.

### `docker:S8544` — why not `>=`

`>=` does not satisfy the rule. It asks for **resolved versions to be locked**, and a range is still unlocked. But pinning a *published library's* dependencies with `==` would force those versions on everyone who installs `frida-gadget`, which is the wrong thing for a library to do.

So the two roles are separated:

| file | form | why |
|---|---|---|
| `setup.py`, `requirements.txt` | `>=` ranges | what a library should express |
| `requirements.lock` | `==`, fully resolved | what the image installs, so a rebuild is reproducible |

The lock was generated with `pip freeze` **inside the image**, so the resolved wheels match linux rather than this machine. `pip` itself is pinned rather than upgraded to whatever is newest.

Verified by rebuilding: the image reports `frida-gadget 1.7.0`, `pip 26.2.1`, and `pip freeze` inside it **matches `requirements.lock` exactly**, no differences.

Note the lower bounds in `setup.py` are conservative floors, not tested minimums — the versions actually exercised are the ones in the lock.
