### PR TITLE
Release 1.7.1

### DIFF
--- a/scripts/__version__.py
+++ b/scripts/__version__.py
@@ -1,6 +1,6 @@
 """frida-gadget version information."""
 __title__ = "frida-gadget"
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 __description__ = "Automated Frida Gadget injection tool"
 __url__ = "https://github.com/ksg97031/frida-gadget"
 __author__ = "ksg97031"


### PR DESCRIPTION
1.7.0 still resolved uber-apk-signer through `/releases/latest` and then ran it with `java -jar`. That was pinned after the upload, so it has not reached anyone installing from PyPI.

The Dockerfile and requirements work from the same batch only affects image builds, so this release exists for the signer pin.

### Why a patch

`1.3.0` is what `/releases/latest` already returned — it is the newest release, from 2023 — so the version the tool actually downloads today does not change. What changes is that it can no longer move on its own, and the expected sha256 is checked against the one the release publishes.

Also in this release: the `signer_version` argument works. `get_assets()` used to overwrite it with the latest tag, so passing a version did nothing.

### Verified against the built artifact

- `twine check` PASSED, all twelve `scripts` modules in the sdist
- Installed the sdist into a clean virtualenv and imported from a neutral directory: no stray top-level `tests`, `frida-gadget --version` → `1.7.1`
- The pin ships and is live in the installed package:
  - default version `1.3.0`, endpoint `.../releases/tags/v1.3.0`
  - pinned sha256 `e1299fd6fcf4da527dd53735...`
  - `UberApkSignerGithub("1.2.1").signer_version` → `1.2.1`, so the argument is honoured
- 93 tests pass, pylint 10.00/10

### Publishing

Same as last time — no PyPI credentials here, so the upload is yours. **Pull first**: the 1.7.0 attempt failed with `400 Bad Request` because the checkout was 35 commits behind and built 1.6.2, which already existed.

```sh
git -C ~/orca/frida-gadget pull && cd ~/orca/frida-gadget && ./pypi.sh
```